### PR TITLE
Detect library changes at startup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,4 +13,5 @@ Contributors:
     Corentin Noël <tintou@mailoo.org>
     Patrick Pace <patrickqpace@gmail.com>
     Adam Davies <adam.davies@outlook.com>
+    Mathias Svanbäck <matteomatic1@gmail.com>
     iTuxer

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -517,7 +517,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         viewSelector.selected = (Widgets.ViewSelector.Mode) Settings.SavedState.get_default ().view_mode;
 
         //rescan music folder for changes made while application not running
-        this.library_manager.rescan_music_folder();
+        library_manager.rescan_music_folder();
         initialization_finished = true;
 
         // Set the focus on the current view

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -516,6 +516,8 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         // Now set the selected view
         viewSelector.selected = (Widgets.ViewSelector.Mode) Settings.SavedState.get_default ().view_mode;
 
+        //rescan music folder for changes made while application not running
+        this.library_manager.rescan_music_folder();
         initialization_finished = true;
 
         // Set the focus on the current view

--- a/src/LocalBackend/LocalLibrary.vala
+++ b/src/LocalBackend/LocalLibrary.vala
@@ -157,7 +157,7 @@ public class Noise.LocalLibrary : Library {
 
         return false;
     }
-    
+
     public void remove_all_static_playlists () {
         var list = new Gee.TreeSet<int64?> ();
         lock (_playlists) {
@@ -176,7 +176,7 @@ public class Noise.LocalLibrary : Library {
         string m_folder = folder;
         m_folder = m_folder.replace ("/media", "");
         m_folder = m_folder.replace (GLib.Environment.get_home_dir ()+ "/", "");
-        
+
         if (start_file_operations (_("Importing music from %s…").printf ("<b>" + Markup.escape_text (m_folder) + "</b>"))) {
             remove_all_static_playlists ();
 
@@ -257,27 +257,28 @@ public class Noise.LocalLibrary : Library {
 
     private async void rescan_music_folder_async () {
         var to_remove = new Gee.TreeSet<Media> ();
-        var to_import = new Gee.TreeSet<string> ();
         var files = new Gee.TreeSet<string> ();
 
-        // get a list of the current files
         var music_folder_dir = Settings.Main.get_default ().music_folder;
-        FileUtils.count_music_files (File.new_for_path (music_folder_dir), files);
-        
-        foreach (var m in get_medias ()) {
-            if (!m.isTemporary && !m.isPreview && m.uri.contains (music_folder_dir))
+        var num_items = FileUtils.count_music_files (File.new_for_path (music_folder_dir), files);
+        debug ("found %d items in imported folder\n", num_items);
 
-            if (!File.new_for_uri (m.uri).query_exists ())
-                to_remove.add (m);
-            if (files.contains (m.uri))
-                files.remove (m.uri);
+        foreach (var m in get_medias()) {
+            if (!m.isTemporary && !m.isPreview && m.uri.contains (music_folder_dir)){
+                if (!File.new_for_uri (m.uri).query_exists ())
+                    to_remove.add (m);
+                //if media is in files, remove it.
+                if (files.contains (m.uri))
+                    files.remove (m.uri);
+            }
         }
 
-        if (!to_import.is_empty) {
-            debug ("Importing %d new songs", to_import.size);
-            fo.resetProgress (to_import.size - 1);
+        //Anything left in files should be imported
+        if (!files.is_empty) {
+            debug ("Importing %d new songs", files.size);
+            fo.resetProgress (files.size - 1);
             Timeout.add (100, doProgressNotificationWithTimeout);
-            fo.import_files (to_import, FileOperator.ImportType.RESCAN);
+            fo.import_files (files, FileOperator.ImportType.RESCAN);
         } else {
             debug ("No new songs to import.");
         }
@@ -286,7 +287,8 @@ public class Noise.LocalLibrary : Library {
             finish_file_operations ();
 
         if (!fo.cancellable.is_cancelled ()) {
-            remove_medias (to_remove, false);
+            if(!to_remove.is_empty)
+                remove_medias (to_remove, false);
         }
     }
 
@@ -518,7 +520,7 @@ public class Noise.LocalLibrary : Library {
 
 
     /******************** Media stuff ******************/
-    
+
     public override void search_medias (string search) {
         if (search == "") {
             lock (_searched_medias) {

--- a/src/LocalBackend/LocalLibrary.vala
+++ b/src/LocalBackend/LocalLibrary.vala
@@ -265,15 +265,17 @@ public class Noise.LocalLibrary : Library {
 
         foreach (var m in get_medias()) {
             if (!m.isTemporary && !m.isPreview && m.uri.contains (music_folder_dir)) {
-                if (!File.new_for_uri (m.uri).query_exists ())
+                if (!File.new_for_uri (m.uri).query_exists ()) {
                     to_remove.add (m);
-                // If media is in files, remove it.
-                if (files.contains (m.uri))
+                }
+
+                if (files.contains (m.uri)) {
                     files.remove (m.uri);
+                }
             }
         }
 
-        //Anything left in files should be imported
+        // Anything left in files should be imported
         if (!files.is_empty) {
             debug ("Importing %d new songs", files.size);
             fo.resetProgress (files.size - 1);
@@ -283,12 +285,14 @@ public class Noise.LocalLibrary : Library {
             debug ("No new songs to import.");
         }
 
-        if (files.is_empty)
+        if (files.is_empty) {
             finish_file_operations ();
+        }
 
         if (!fo.cancellable.is_cancelled ()) {
-            if(!to_remove.is_empty)
+            if(!to_remove.is_empty) {
                 remove_medias (to_remove, false);
+            }
         }
     }
 

--- a/src/LocalBackend/LocalLibrary.vala
+++ b/src/LocalBackend/LocalLibrary.vala
@@ -197,7 +197,7 @@ public class Noise.LocalLibrary : Library {
         var files = new Gee.TreeSet<string> ();
 
         var items = FileUtils.count_music_files (music_folder_file, files);
-        debug ("Found %d items to import in %s\n", items, music_folder_file);
+        debug ("Found %d items to import in %s\n", items, folder);
 
         fo.resetProgress (files.size - 1);
         Timeout.add (100, doProgressNotificationWithTimeout);
@@ -261,7 +261,7 @@ public class Noise.LocalLibrary : Library {
 
         var music_folder_dir = Settings.Main.get_default ().music_folder;
         var num_items = FileUtils.count_music_files (File.new_for_path (music_folder_dir), files);
-        debug ("Found %d items to import in %s\n", items, music_folder_file);
+        debug ("Found %d items to import in %s\n", num_items, music_folder_dir);
 
         foreach (var m in get_medias()) {
             if (!m.isTemporary && !m.isPreview && m.uri.contains (music_folder_dir)) {

--- a/src/LocalBackend/LocalLibrary.vala
+++ b/src/LocalBackend/LocalLibrary.vala
@@ -197,7 +197,7 @@ public class Noise.LocalLibrary : Library {
         var files = new Gee.TreeSet<string> ();
 
         var items = FileUtils.count_music_files (music_folder_file, files);
-        debug ("found %d items to import\n", items);
+        debug ("Found %d items to import in %s\n", items, music_folder_file);
 
         fo.resetProgress (files.size - 1);
         Timeout.add (100, doProgressNotificationWithTimeout);
@@ -261,10 +261,10 @@ public class Noise.LocalLibrary : Library {
 
         var music_folder_dir = Settings.Main.get_default ().music_folder;
         var num_items = FileUtils.count_music_files (File.new_for_path (music_folder_dir), files);
-        debug ("found %d items in imported folder\n", num_items);
+        debug ("Found %d items to import in %s\n", items, music_folder_file);
 
         foreach (var m in get_medias()) {
-            if (!m.isTemporary && !m.isPreview && m.uri.contains (music_folder_dir)){
+            if (!m.isTemporary && !m.isPreview && m.uri.contains (music_folder_dir)) {
                 if (!File.new_for_uri (m.uri).query_exists ())
                     to_remove.add (m);
                 //if media is in files, remove it.

--- a/src/LocalBackend/LocalLibrary.vala
+++ b/src/LocalBackend/LocalLibrary.vala
@@ -267,7 +267,7 @@ public class Noise.LocalLibrary : Library {
             if (!m.isTemporary && !m.isPreview && m.uri.contains (music_folder_dir)) {
                 if (!File.new_for_uri (m.uri).query_exists ())
                     to_remove.add (m);
-                //if media is in files, remove it.
+                // If media is in files, remove it.
                 if (files.contains (m.uri))
                     files.remove (m.uri);
             }


### PR DESCRIPTION
Re-scan the local music folder at startup for any changes made while the application wasn't running.
related to https://bugs.launchpad.net/noise/+bug/1073871