### PR TITLE
Remove unused local variable rating_search

### DIFF
--- a/src/LocalBackend/LocalLibrary.vala
+++ b/src/LocalBackend/LocalLibrary.vala
@@ -538,7 +538,6 @@ public class Noise.LocalLibrary : Library {
         uint parsed_rating;
         string parsed_search_string;
         String.base_search_method (search, out parsed_rating, out parsed_search_string);
-        bool rating_search = parsed_rating > 0;
         // If we search for a special rating, don't search for something else.
         try {
             if (parsed_rating > 0) {


### PR DESCRIPTION
The comparison is carried out on line 544 and the variable never used, as it is only carried out once there is no reason to use the variable here.