### PR TITLE
Remove unnecessary construct Playlist name property.

### DIFF
--- a/core/Playlists/Playlist.vala
+++ b/core/Playlists/Playlist.vala
@@ -38,7 +38,7 @@ public abstract class Noise.Playlist : Object {
         get {
             return _name;
         }
-        construct set {
+        set {
             string old_name = _name;
             _name = value;
             updated (old_name);

--- a/src/LocalBackend/LocalSmartPlaylist.vala
+++ b/src/LocalBackend/LocalSmartPlaylist.vala
@@ -43,7 +43,8 @@ public class Noise.LocalSmartPlaylist : SmartPlaylist {
             _name = Database.query_field (rowid, connection, Database.SmartPlaylists.TABLE_NAME, "name").dup_string ();
             return _name;
         }
-        construct set {
+
+        set {
             _name = value;
             Database.set_field (rowid, connection, Database.SmartPlaylists.TABLE_NAME, "name", value);
         }

--- a/src/LocalBackend/LocalStaticPlaylist.vala
+++ b/src/LocalBackend/LocalStaticPlaylist.vala
@@ -41,7 +41,7 @@ public class Noise.LocalStaticPlaylist : StaticPlaylist {
             _name = Database.query_field (rowid, connection, Database.Playlists.TABLE_NAME, "name").dup_string ();
             return _name;
         }
-        construct set {
+        set {
             _name = value;
             Database.set_field (rowid, connection, Database.Playlists.TABLE_NAME, "name", value);
         }


### PR DESCRIPTION
Constructing the name property  (when it just gets set to null), before the connection is assigned, results in critical terminal warning.