### PR TITLE
Fix possibly unassigned

### DIFF
--- a/core/Utils/String.vala
+++ b/core/Utils/String.vala
@@ -112,7 +112,7 @@ namespace Noise.String {
      *
      * For example:
      * "This is an input string" => "This Is An Input String"
-     * "example string/text"     => "Example String/Text" 
+     * "example string/text"     => "Example String/Text"
      */
     public inline string to_title_case (string text) {
         bool capitalize_next = true;
@@ -153,7 +153,7 @@ namespace Noise.String {
 
         return string_utf8;
     }
-    
+
     /**
      * Base method used for searches. It does a previous parsing on the search string.
      *
@@ -162,7 +162,7 @@ namespace Noise.String {
      * the value of parsed_search_string.
      *
      * @param search Non-parsed version of the search string.
-     * @param parsed_rating location where the parsed rating it stored, or -1 if the
+     * @param parsed_rating location where the parsed rating it stored, or 0 if the
      * string didn't represent a valid rating.
      * @param parsed_search_string location where the canonicalized version of the
      * search string is stored. Should be passed to the methods in Noise.Search.
@@ -170,12 +170,11 @@ namespace Noise.String {
     public static void base_search_method (string search, out uint parsed_rating,
                                            out string parsed_search_string)
     {
-        var result = Search.get_rating_from_string (search.strip ());
+        parsed_rating = 0;
+        var result = Search.get_rating_from_string (search.strip ()); // guaranteed > 0 or null
 
         if (result != null) {
-            parsed_rating = parsed_rating.clamp (1, 5);
-        } else {
-            parsed_rating = 0;
+            parsed_rating = result.clamp (1, 5);
         }
 
         parsed_search_string = Search.get_valid_search_string (search);

--- a/src/Widgets/FastView/FastListModel.vala
+++ b/src/Widgets/FastView/FastListModel.vala
@@ -228,8 +228,8 @@ public class Noise.FastModel : GLib.Object, Gtk.TreeModel, Gtk.TreeSortable {
     /** The following functions are for implementing TreeSortable. We pass
      * off responsibility to sort things to the view.
     **/
-    public bool get_sort_column_id (out int sort_column_id, out Gtk.SortType order) {
-        this.sort_column_id = sort_column_id;
+    public bool get_sort_column_id (out int column_id, out Gtk.SortType order) {
+        column_id = sort_column_id;
         order = sort_direction;
 
         return true;

--- a/src/Widgets/FastView/FastListModel.vala
+++ b/src/Widgets/FastView/FastListModel.vala
@@ -90,6 +90,8 @@ public class Noise.FastModel : GLib.Object, Gtk.TreeModel, Gtk.TreeSortable {
     }
 
     public void get_value (Gtk.TreeIter iter, int column, out Value val) {
+        val = { };
+
         if (iter.stamp != stamp || column < 0 || column >= get_n_columns ()) {
             return;
         }


### PR DESCRIPTION
Fix code so "use of possibly unassigned" compilation errors are not produced.

The third commit also corrects a logical error in the function where the assignment was the wrong way around.