### PR TITLE
Remove App.get_id

### DIFF
--- a/plugins/MPRIS/SoundMenuIntegration.vala
+++ b/plugins/MPRIS/SoundMenuIntegration.vala
@@ -40,7 +40,7 @@ public class Noise.SoundMenuIntegration : Object {
 		/* set up the server to connect to music.noise dbus */
 		var app = (Noise.App) GLib.Application.get_default ();
 		server = Indicate.Server.ref_default();
-		server.set ("type", "music" + "." + app.get_id ());
+		server.set ("type", "music" + "." + app.get_application_id ());
 		var desktop_file_path = GLib.Path.build_filename (Build.DATADIR, "applications",
 		                                                  app.get_desktop_file_name ());
 		server.set_desktop_file (desktop_file_path);

--- a/src/Noise.vala
+++ b/src/Noise.vala
@@ -102,14 +102,6 @@ public class Noise.App : Granite.Application {
     }
 
     /**
-     * We use this identifier to init everything inside the application.
-     * For instance: libnotify, etc.
-     */
-    public string get_id () {
-        return application_id;
-    }
-
-    /**
      * @return the application's brand name. Should be used for anything that requires
      * branding. For instance: Ubuntu's sound menu, dialog titles, etc.
      */


### PR DESCRIPTION
GLib.Application already provides get_application_id which serves the same purpose.