### PR TITLE
Use Granite.Application fields

### DIFF
--- a/plugins/MPRIS/MPRIS.vala
+++ b/plugins/MPRIS/MPRIS.vala
@@ -103,7 +103,7 @@ public class MprisRoot : GLib.Object {
     
     public string Identity {
         owned get {
-            return ((Noise.App) GLib.Application.get_default ()).get_name ();
+            return ((Noise.App) GLib.Application.get_default ()).program_name;
         }
     }
     

--- a/plugins/MPRIS/SoundMenuIntegration.vala
+++ b/plugins/MPRIS/SoundMenuIntegration.vala
@@ -42,7 +42,7 @@ public class Noise.SoundMenuIntegration : Object {
 		server = Indicate.Server.ref_default();
 		server.set ("type", "music" + "." + app.get_application_id ());
 		var desktop_file_path = GLib.Path.build_filename (Build.DATADIR, "applications",
-		                                                  app.get_desktop_file_name ());
+		                                                  app.app_launcher);
 		server.set_desktop_file (desktop_file_path);
 		server.show ();
 	}

--- a/src/Dialogs/NotImportedWindow.vala
+++ b/src/Dialogs/NotImportedWindow.vala
@@ -59,7 +59,7 @@ public class Noise.NotImportedWindow : Gtk.Dialog {
         title.halign = Gtk.Align.START;
         title.hexpand = true;
         title.set_markup ("<span weight=\"bold\" size=\"larger\">" + Markup.escape_text (_("Unable to import %d items from %s").printf (files.size, music_folder), -1) + "</span>");
-        var info = new Gtk.Label (_("%s was unable to import %d items. The files may be damaged.").printf (((Noise.App) GLib.Application.get_default ()).get_name (), files.size));
+        var info = new Gtk.Label (_("%s was unable to import %d items. The files may be damaged.").printf (((Noise.App) GLib.Application.get_default ()).program_name, files.size));
         info.halign = Gtk.Align.START;
         info.set_line_wrap (false);
         var trashAll = new Gtk.CheckButton.with_label (_("Move all corrupted files to trash"));

--- a/src/Dialogs/RemoveFilesDialog.vala
+++ b/src/Dialogs/RemoveFilesDialog.vala
@@ -36,7 +36,7 @@ public class Noise.RemoveFilesDialog : Gtk.Dialog {
     private Gtk.Button cancel_button;
 
     public RemoveFilesDialog (Gee.Collection<Media> to_remove, ViewWrapper.Hint media_type) {
-        var app_name = ((Noise.App) GLib.Application.get_default ()).get_name ();
+        var app_name = ((Noise.App) GLib.Application.get_default ()).program_name;
 
         this.set_modal(true);
         this.set_transient_for (App.main_window);

--- a/src/FileOperator.vala
+++ b/src/FileOperator.vala
@@ -302,7 +302,7 @@ public class Noise.FileOperator : Object {
         }
 
         if (all_new_imports.size > 0)
-            App.main_window.show_notification (_("Import Complete"), _("%s has imported your library.").printf (((Noise.App) GLib.Application.get_default ()).get_name ()));
+            App.main_window.show_notification (_("Import Complete"), _("%s has imported your library.").printf (((Noise.App) GLib.Application.get_default ()).program_name));
 
         if (import_type == ImportType.PLAYLIST) {
             new_playlist.add_medias (all_new_imports);

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -227,7 +227,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
             maximize ();
         }
 
-        title = ((Noise.App) GLib.Application.get_default ()).get_name ();
+        title = ((Noise.App) GLib.Application.get_default ()).program_name;
         icon_name = "multimedia-audio-player";
 
         // set up drag dest stuff
@@ -290,7 +290,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         headerbar.pack_start (viewSelector);
         headerbar.pack_end (menu_button);
         headerbar.pack_end (searchField);
-        headerbar.set_title (((Noise.App) GLib.Application.get_default ()).get_name ());
+        headerbar.set_title (((Noise.App) GLib.Application.get_default ()).program_name);
         headerbar.set_custom_title (top_display);
         headerbar.show_all ();
 
@@ -1164,7 +1164,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     public void doAlert(string title, string message) {
         var dialog = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, "%s", title);
 
-        dialog.title = ((Noise.App) GLib.Application.get_default ()).get_name ();
+        dialog.title = ((Noise.App) GLib.Application.get_default ()).program_name;
         dialog.secondary_text = message;
         dialog.secondary_use_markup = true;
 

--- a/src/Noise.vala
+++ b/src/Noise.vala
@@ -100,19 +100,4 @@ public class Noise.App : Granite.Application {
 
         main_window.present ();
     }
-
-    /**
-     * @return the application's brand name. Should be used for anything that requires
-     * branding. For instance: Ubuntu's sound menu, dialog titles, etc.
-     */
-    public string get_name () {
-        return program_name;
-    }
-
-    /**
-     * @return the application's desktop file name.
-     */
-    public string get_desktop_file_name () {
-        return app_launcher;
-    }
 }


### PR DESCRIPTION
Removes get_name and get_desktop_file_name from Noise.App and instead directly uses fields.