### PR TITLE
Simplify repeat modes

### DIFF
--- a/core/Player.vala
+++ b/core/Player.vala
@@ -27,7 +27,6 @@
  */
 
 public interface Noise.Player : Object {
-
     public abstract void add_playback (Noise.Playback p);
 
     public enum Shuffle {
@@ -38,10 +37,6 @@ public interface Noise.Player : Object {
     public enum Repeat {
         OFF,
         MEDIA,
-        ALBUM,
-        ARTIST,
         ALL
     }
-
-    // TODO: ...
 }

--- a/data/org.pantheon.noise.gschema.xml
+++ b/data/org.pantheon.noise.gschema.xml
@@ -3,9 +3,7 @@
   <enum id="org.pantheon.noise.repeat">
     <value value="0" nick="off"/>
     <value value="1" nick="media"/>
-    <value value="2" nick="album"/>
-    <value value="3" nick="artist"/>
-    <value value="4" nick="all"/>
+    <value value="2" nick="all"/>
   </enum>
   <enum id="org.pantheon.noise.shuffle">
     <value value="0" nick="off"/>

--- a/src/Widgets/SimpleOptionChooser.vala
+++ b/src/Widgets/SimpleOptionChooser.vala
@@ -27,97 +27,47 @@
  */
 
 public class Noise.SimpleOptionChooser : Gtk.EventBox {
-    public Gee.LinkedList<Gtk.RadioMenuItem> items;
-    public Gee.LinkedList<Gtk.Image> images;
-
-    private int clicked_index;
-    private int previous_index; // for left click
-    private bool toggling;
-
-    private Gtk.Menu? menu = null;
-
-    public int current_option { get { return clicked_index; } }
+    public Gee.ArrayList<Gtk.Image> options { get; set; }
+    public int current_option { get; private set; }
 
     public signal void option_changed (bool by_user = false);
 
-    public SimpleOptionChooser () {
-        items = new Gee.LinkedList<Gtk.RadioMenuItem> ();
-        images = new Gee.LinkedList<Gtk.Image> ();
-        toggling = false;
-
-        clicked_index = 0;
-        previous_index = 0;
+    construct {
+        options = new Gee.ArrayList<Gtk.Image> ();
+        current_option = 0;
     }
 
-    public void set_option (int index, bool notify = true) {
-        if (index >= items.size) {
+    public void set_option (int index, bool by_user = false) {
+        if (index >= options.size) {
             return;
         }
 
-        items.get (index).set_active (true);
-
-        clicked_index = index;
-
-        if (notify) {
-            option_changed ();
-        }
+        current_option = index;
+        option_changed (by_user);
 
         if (get_child () != null) {
             remove (get_child ());
         }
 
-        add (images.get (index));
-
+        add (options[index]);
         show_all ();
     }
 
-    public int append_item (string text, string icon_name, string tooltip) {
-        Gtk.RadioMenuItem item;
-
-        if (items.size == 0) {
-            item = new Gtk.RadioMenuItem.with_label (new SList<Gtk.RadioMenuItem>(), text);
-        } else {
-            item = new Gtk.RadioMenuItem.with_label_from_widget (items.get(0), text);
-        }
-
+    public int append_item (string icon_name, string tooltip) {
         var image = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.MENU);
         image.tooltip_text = tooltip;
 
-        items.add (item);
-        images.add (image);
+        options.add (image);
 
-        if (menu == null) {
-            menu = new Gtk.Menu ();
-        }
-        menu.append (item);
-
-        item.toggled.connect (() => {
-            if (item.active) {
-                set_option (items.index_of (item));
-            }
-        });
-
-        item.show ();
-        previous_index = items.size - 1; // my lazy way of making sure the bottom item is the default on/off on click
-
-        return items.size - 1;
+        return options.size - 1;
     }
 
     public override bool button_press_event (Gdk.EventButton event) {
         if (event.type == Gdk.EventType.BUTTON_PRESS) {
-            if (event.button == 1) {
-                // Silently set the options. We emit the option_changed signal below.
-                if (clicked_index == 0) {
-                    set_option (previous_index, false);
-                } else {
-                    previous_index = clicked_index;
-                    set_option (0, false);
-                }
-
-                option_changed (true); // #true since the user made the change
-            } else if (menu != null && items.size > 1) {
-                menu.popup (null, null, null, 3, event.time);
-            }
+            var next = current_option + 1 < options.size
+                ? current_option + 1
+                : 0;
+            set_option (next, true);
         }
 
         return true;

--- a/src/Widgets/TopDisplay.vala
+++ b/src/Widgets/TopDisplay.vala
@@ -136,11 +136,9 @@ public class Noise.TopDisplay : Gtk.Stack {
     private class RepeatChooser : SimpleOptionChooser {
         public RepeatChooser () {
             // MUST follow the exact same order of Noise.Player.Repeat
-            append_item (_("Off"), "media-playlist-no-repeat-symbolic", _("Enable Repeat"));
-            append_item (_("Song"), "media-playlist-repeat-song-symbolic", _("Repeat Song"));
-            append_item (_("Album"), "media-playlist-repeat-symbolic", _("Repeat Album"));
-            append_item (_("Artist"), "media-playlist-repeat-symbolic", _("Repeat Artist"));
-            append_item (_("All"), "media-playlist-repeat-symbolic", _("Disable Repeat"));
+            append_item ("media-playlist-no-repeat-symbolic", _("Enable Repeat"));
+            append_item ("media-playlist-repeat-song-symbolic", _("Repeat Song"));
+            append_item ("media-playlist-repeat-symbolic", _("Disable Repeat"));
 
             update_option ();
 
@@ -166,8 +164,8 @@ public class Noise.TopDisplay : Gtk.Stack {
 
     private class ShuffleChooser : SimpleOptionChooser {
         public ShuffleChooser () {
-            append_item (_("Off"), "media-playlist-consecutive-symbolic", _("Enable Shuffle"));
-            append_item (_("All"), "media-playlist-shuffle-symbolic", _("Disable Shuffle"));
+            append_item ("media-playlist-consecutive-symbolic", _("Enable Shuffle"));
+            append_item ("media-playlist-shuffle-symbolic", _("Disable Shuffle"));
 
             update_mode ();
 


### PR DESCRIPTION
We only have three states now: off, song or all

Drop the context menu on both the repeat chooser and the shuffle mode selector

Fixes #71 