### PR TITLE
SyncWarningDialog.vala: subclass Granite.MessageDialog

### DIFF
--- a/src/Views/DeviceSummaryWidget.vala
+++ b/src/Views/DeviceSummaryWidget.vala
@@ -313,7 +313,7 @@ public class Noise.DeviceSummaryWidget : Gtk.EventBox {
             libraries_manager.local_library.media_from_name (dev.get_library ().get_medias(), found, not_found);
 
             if(not_found.size > 0) { // hand control over to SWD
-                SyncWarningDialog swd = new SyncWarningDialog(dev, list, not_found);
+                var swd = new SyncWarningDialog (dev, list, not_found);
                 swd.response.connect ((src, id) => {
                     switch (id) {
                         case SyncWarningDialog.ResponseId.IMPORT_MEDIA:
@@ -331,7 +331,6 @@ public class Noise.DeviceSummaryWidget : Gtk.EventBox {
                             break;
                     }
                 });
-                swd.show();
             } else {
                 space_widget.set_sync_button_sensitive(false);
                 dev.synchronize ();


### PR DESCRIPTION
Subclass Granite.MessageDialog instead of Gtk.Dialog to save ourselves some work and get proper styling and alignment.

While we're here:
* change the icon from error (no error has actually occurred) to warning
* change the cancel action label to "Cancel"
* change the import action label to "Import"
* Add destructive and suggested action style classes
* Buttons in HIG order (Alternate, Cancel, Affirmative)

**OLD**

![screenshot from 2017-12-05 11 03 18](https://user-images.githubusercontent.com/7277719/33625301-fc0ce732-d9ab-11e7-91cd-f0cdfa9dacc0.png)


**NEW**

![screenshot from 2017-12-05 10 57 40](https://user-images.githubusercontent.com/7277719/33625253-dd40e74a-d9ab-11e7-9d79-a89dea75757c.png)

