### PR TITLE
Fix icon warnings

### DIFF
--- a/core/Album.vala
+++ b/core/Album.vala
@@ -161,7 +161,7 @@ public class Noise.Album : Object {
             return null;
         }
 
-        var icon_info = Gtk.IconTheme.get_default ().lookup_by_gicon_for_scale (cover_icon, 128, scale, Gtk.IconLookupFlags.GENERIC_FALLBACK);
+        var icon_info = Gtk.IconTheme.get_default ().lookup_by_gicon_for_scale (cover_icon, 128, scale, 0);
         icon_info.load_icon_async.begin (null, (obj, res) => {
             try {
                 cover_pixbuf = icon_info.load_icon_async.end (res);

--- a/core/Utils/Icon.vala
+++ b/core/Utils/Icon.vala
@@ -35,17 +35,11 @@
  * The icon is searched in the available icon themes.
  */
 public class Noise.Icon : Object {
-
     private static Gtk.IconTheme? _theme;
     public static Gtk.IconTheme theme {
         get {
             if (_theme == null) {
                 _theme = Gtk.IconTheme.get_default ();
-
-                // This only works if Build.ICON_DIR contains a sub-directory named "hicolor"
-                // containing all the fallback icons (possibly organized into sub-folders as well),
-                // or if the icons are immediate children of this directory.
-                _theme.append_search_path (Path.build_filename (Build.ICON_DIR));
             }
 
             return _theme;
@@ -54,7 +48,6 @@ public class Noise.Icon : Object {
 
     public string? name { get; private set; }
     public GLib.Icon gicon { get; private set; }
-
 
     /**
      * Creates a new icon object.
@@ -67,19 +60,8 @@ public class Noise.Icon : Object {
         gicon = new ThemedIcon (this.name);
     }
 
-
     public Gtk.IconInfo? get_icon_info (int size) {
         return theme.lookup_by_gicon (gicon, size, Gtk.IconLookupFlags.USE_BUILTIN);
-    }
-
-    /**
-     * Returns a file representing the icon in the filesystem.
-     * @param size Icon size to query.
-     * @return A {@link GLib.File} representing the icon, or //null// if none is found.
-     */
-    public File? get_file (int size = 16) {
-        var info = get_icon_info (size);
-        return info != null ? File.new_for_path (info.get_filename ()) : null;
     }
 
     /**

--- a/core/Utils/Icon.vala
+++ b/core/Utils/Icon.vala
@@ -65,6 +65,16 @@ public class Noise.Icon : Object {
     }
 
     /**
+     * Returns a file representing the icon in the filesystem.
+     * @param size Icon size to query.
+     * @return A {@link GLib.File} representing the icon, or //null// if none is found.
+     */
+    public File? get_file (int size = 16) {
+        var info = get_icon_info (size);
+        return info != null ? File.new_for_path (info.get_filename ()) : null;
+    }
+
+    /**
      * Creates a new {@link Gdk.Pixbuf} from the icon at the specified icon size.
      *
      * @param size The pixbuf's icon size.

--- a/src/Views/GridView.vala
+++ b/src/Views/GridView.vala
@@ -28,7 +28,6 @@
  */
 
 public class Noise.GridView : ContentView, ViewTextOverlay {
-    private Gdk.Pixbuf fallback_pixbuf;
     private Gtk.Paned hpaned;
     private FastGrid icon_view;
 
@@ -157,14 +156,6 @@ public class Noise.GridView : ContentView, ViewTextOverlay {
     }
 
     public void reset_pixbufs () {
-        var scale = get_style_context ().get_scale ();
-        var icon_info = Gtk.IconTheme.get_default ().lookup_by_gicon_for_scale (new ThemedIcon ("albumart"), 128, scale, Gtk.IconLookupFlags.GENERIC_FALLBACK);
-        try {
-            fallback_pixbuf = icon_info.load_icon ();
-        } catch (Error e) {
-            critical (e.message);
-        }
-
         queue_draw ();
     }
 


### PR DESCRIPTION
This fixes several warnings in the Terminal about failing to lookup icons

Album.vala:
* No additional icon lookup flags

Icon.vala:
* Don't try to append an icon directory since we use gresource now instead
* Whitespace

GridView.vala:
* Don't try to load a non-existent fallback pixbuf since we draw that in Gtk.CSS now
