### PR TITLE
LibraryWindow.vala: port saved_state to GLib.Settings

### DIFF
--- a/core/Settings.vala
+++ b/core/Settings.vala
@@ -28,11 +28,6 @@
 
 namespace Noise.Settings {
     public class SavedState : Granite.Services.Settings {
-
-        public int window_width { get; set; }
-        public int window_height { get; set; }
-        public WindowState window_state { get; set; }
-        public int sidebar_width { get; set; }
         public int view_mode { get; set; }
         public int column_browser_width { get; set; }
         public int column_browser_height { get; set; }
@@ -143,11 +138,5 @@ namespace Noise.Settings {
         ALBUM,
         ARTIST,
         ALL
-    }
-
-    public enum WindowState {
-        NORMAL,
-        MAXIMIZED,
-        FULLSCREEN
     }
 }

--- a/core/Settings.vala
+++ b/core/Settings.vala
@@ -28,7 +28,6 @@
 
 namespace Noise.Settings {
     public class SavedState : Granite.Services.Settings {
-        public int view_mode { get; set; }
         public int column_browser_width { get; set; }
         public int column_browser_height { get; set; }
         public bool column_browser_enabled { get; set; }

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -260,10 +260,11 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         grid.add (statusbar);
 
         main_hpaned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
-        main_hpaned.position = saved_state_settings.get_int ("sidebar-width");
         main_hpaned.pack1 (grid, false, false);
         main_hpaned.pack2 (view_container, true, false);
         main_hpaned.show_all ();
+
+        saved_state_settings.bind ("sidebar-width", main_hpaned, "position", GLib.SettingsBindFlags.DEFAULT);
 
         add (main_hpaned);
         set_titlebar (headerbar);
@@ -1147,7 +1148,6 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
             main_settings.search_string = search_entry.text;
         }
 
-        saved_state_settings.set_int ("sidebar-width", main_hpaned.position);
         saved_state_settings.set_int ("view-mode", view_selector.selected);
 
         if (is_maximized) {

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -453,7 +453,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         load_playlists ();
         update_sensitivities_sync (); // we need to do this synchronously to avoid weird initial states
 
-        view_selector.selected = (Widgets.ViewSelector.Mode) Settings.SavedState.get_default ().view_mode;
+        view_selector.selected = (Widgets.ViewSelector.Mode) saved_state_settings.get_int ("view-mode");
 
         library_manager.rescan_music_folder ();
         initialization_finished = true;


### PR DESCRIPTION
Port the saved state settings in LibraryWindow to GLib.Settings instead of Granite Settings

* Remove now unused properties and enum from Settings.vala
* Decrease the scope of `window_height` and `window_width` to `configure_event`
* Increase the scope of `saved_state_settings` instead of recreating it in several methods
* Respect window manager defaults for placing windows without saved coords (For Gala this is still center, so no change)
* Bind `sidebar-width` instead of get/set