### PR TITLE
DeviceView.vala: misc cleanup

### DIFF
--- a/core/Devices/Device.vala
+++ b/core/Devices/Device.vala
@@ -31,7 +31,7 @@
 public interface Noise.Device : GLib.Object {
     public signal void initialized (Device d);
     public signal void device_unmounted ();
-    public signal void infobar_message (string message, Gtk.MessageType type);
+    public signal void infobar_message (string label, Gtk.MessageType message_type);
 
     public abstract bool start_initialization();
     public abstract void finish_initialization();

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -282,7 +282,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         source_list_view.item_action_activated.connect ((page_number) => {
             var view = view_container.get_view (page_number);
             if (view is DeviceView) {
-                ((DeviceView)view).d.eject ();
+                ((DeviceView) view).device.eject ();
             }
         });
         source_list_view.edited.connect (playlist_name_edited);

--- a/src/Views/DeviceView.vala
+++ b/src/Views/DeviceView.vala
@@ -29,8 +29,6 @@
 public class Noise.DeviceView : Gtk.Grid {
     public Device device { get; construct; }
     public DevicePreferences preferences { get; construct;}
-    
-    private DeviceSummaryWidget summary;
 
     public DeviceView (Noise.Device device, DevicePreferences preferences) {
         Object (
@@ -47,7 +45,7 @@ public class Noise.DeviceView : Gtk.Grid {
         infobar.add_button (_("Close"), 0);
         infobar.get_content_area ().add (infobar_label);
 
-        summary = new DeviceSummaryWidget (device, preferences);
+        var summary = new DeviceSummaryWidget (device, preferences);
 
         orientation = Gtk.Orientation.VERTICAL;
         attach (infobar, 0, 0, 1, 1);

--- a/src/Views/DeviceView.vala
+++ b/src/Views/DeviceView.vala
@@ -36,7 +36,7 @@ public class Noise.DeviceView : Gtk.Grid {
             preferences: preferences
         );
     }
-    
+
     construct {
         var infobar_label = new Gtk.Label ("");
 
@@ -58,7 +58,7 @@ public class Noise.DeviceView : Gtk.Grid {
         }
 
         show_all ();
-        
+
         infobar.hide ();
 
         ulong connector = NotificationManager.get_default ().progress_canceled.connect (() => {

--- a/src/Views/DeviceView.vala
+++ b/src/Views/DeviceView.vala
@@ -28,7 +28,7 @@
 
 public class Noise.DeviceView : Gtk.Grid {
     public Device device { get; construct; }
-    public DevicePreferences preferences { get; construct;}
+    public DevicePreferences preferences { get; construct; }
 
     public DeviceView (Noise.Device device, DevicePreferences preferences) {
         Object (
@@ -67,7 +67,7 @@ public class Noise.DeviceView : Gtk.Grid {
             }
         });
 
-        device.device_unmounted.connect ( () => {
+        device.device_unmounted.connect (() => {
             message ("device unmounted\n");
             device.disconnect (connector);
         });


### PR DESCRIPTION
* GObject style
* `d` -> `device
* Reduce variable scope
* Remove unneeded cast to Gtk.Container in infobar
* "OK" -> "Close"
* Connect signals at the bottom
* Properties instead of get/set
* Organize
* Remove unused `set_as_current_view`
* Don't get device custom view twice