### PR TITLE
Statusbar menubutton sensitive

### DIFF
--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -643,7 +643,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
 
         // hide playlists when media list is empty
         source_list_view.change_playlist_category_visibility (have_media);
-        statusbar.playlist_menubutton_sensitive = have_media;
+        statusbar.playlist_menubutton_sensitive = folder_set && have_media;
 
         if (!media_active || have_media && !App.player.playing)
             play_button.set_image (new Gtk.Image.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR));

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -40,7 +40,11 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     public Widgets.ViewSelector view_selector { get; private set; }
     public Gtk.SearchEntry search_entry { get; private set; }
     public Widgets.StatusBar statusbar { get; private set; }
-    public Noise.LocalLibrary library_manager { get { return (Noise.LocalLibrary)libraries_manager.local_library; } }
+    public Noise.LocalLibrary library_manager {
+        get {
+            return (Noise.LocalLibrary) libraries_manager.local_library;
+        }
+    }
 
     private bool media_considered_played { get; set; default = false; } // whether or not we have updated last played and added to already played list
     private bool added_to_play_count { get; set; default = false; } // whether or not we have added one to play count on playing media
@@ -643,11 +647,10 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
 
         // hide playlists when media list is empty
         source_list_view.change_playlist_category_visibility (have_media);
+        statusbar.playlist_menubutton_sensitive = have_media;
 
         if (!media_active || have_media && !App.player.playing)
             play_button.set_image (new Gtk.Image.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR));
-
-        statusbar.update_sensitivities ();
     }
 
     /**

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -40,11 +40,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     public Widgets.ViewSelector view_selector { get; private set; }
     public Gtk.SearchEntry search_entry { get; private set; }
     public Widgets.StatusBar statusbar { get; private set; }
-    public Noise.LocalLibrary library_manager {
-        get {
-            return (Noise.LocalLibrary) libraries_manager.local_library;
-        }
-    }
+    public Noise.LocalLibrary library_manager { get { return (Noise.LocalLibrary)libraries_manager.local_library; } }
 
     private bool media_considered_played { get; set; default = false; } // whether or not we have updated last played and added to already played list
     private bool added_to_play_count { get; set; default = false; } // whether or not we have added one to play count on playing media

--- a/src/Widgets/StatusBar.vala
+++ b/src/Widgets/StatusBar.vala
@@ -25,10 +25,15 @@
  */
 
 namespace Noise.Widgets {
-
     public class StatusBar : Gtk.ActionBar {
-        private Gtk.MenuButton playlist_menubutton;
         public Gtk.Widget equalizer_item { get; private set; default = new EqualizerChooser (); }
+
+        private Gtk.MenuButton playlist_menubutton;
+        public bool playlist_menubutton_sensitive {
+            set {
+                playlist_menubutton.sensitive = value;
+            }
+        }
 
         public StatusBar () {
             var add_pl_menuitem = new Gtk.MenuItem.with_label (_("Add Playlist"));
@@ -56,11 +61,6 @@ namespace Noise.Widgets {
             add_spl_menuitem.activate.connect (() => {
                 App.main_window.show_smart_playlist_dialog ();
             });
-        }
-
-        public void update_sensitivities () {
-            var local_library = (LocalLibrary) libraries_manager.local_library;
-            playlist_menubutton.set_sensitive (local_library.main_directory_set && local_library.get_medias ().size > 0);
         }
     }
 

--- a/src/Widgets/StatusBar.vala
+++ b/src/Widgets/StatusBar.vala
@@ -26,14 +26,14 @@
 
 namespace Noise.Widgets {
     public class StatusBar : Gtk.ActionBar {
-        public Gtk.Widget equalizer_item { get; private set; default = new EqualizerChooser (); }
-
         private Gtk.MenuButton playlist_menubutton;
         public bool playlist_menubutton_sensitive {
             set {
                 playlist_menubutton.sensitive = value;
             }
         }
+
+        public Gtk.Widget equalizer_item { get; private set; default = new EqualizerChooser (); }
 
         public StatusBar () {
             var add_pl_menuitem = new Gtk.MenuItem.with_label (_("Add Playlist"));


### PR DESCRIPTION
We already run this check (`have_media`) in LibraryWindow.vala in order to set the source list category visibility. Instead of running the same check twice, just use the cached result of the first check and make statusbar dumber