### PR TITLE
TileRenderer.vala: Fix compile error with Gtk.Border

### DIFF
--- a/src/Widgets/FastView/TileView/TileRenderer.vala
+++ b/src/Widgets/FastView/TileView/TileRenderer.vala
@@ -171,7 +171,6 @@ internal class Noise.Widgets.TileRenderer : Gtk.CellRenderer {
 
         pixbuf = album.get_cached_cover_pixbuf (1);
 
-        var border = Gtk.Border ();
         border.left = 12;
         border.right = 12;
         border.bottom = 12;


### PR DESCRIPTION
This fixes an error `conversion to non-scalar type requested`