### PR TITLE
No longer reference usr/share

### DIFF
--- a/debian/noise.install
+++ b/debian/noise.install
@@ -4,6 +4,5 @@ usr/share/applications
 usr/share/glib-2.0
 usr/share/icons
 usr/share/locale
-usr/share/noise
 usr/share/accounts
 usr/share/metainfo


### PR DESCRIPTION
This should fix a packaging build failure. We no longer install anything to `/usr/share/noise` since all assets are now bundled into a gresource