### PR TITLE
LibraryWindow.vala: Make public things private

### DIFF
--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -273,7 +273,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         connect_to_sourcelist_signals ();
     }
 
-    public void connect_to_sourcelist_signals () {
+    private void connect_to_sourcelist_signals () {
 
         source_list_view.selection_changed.connect ((page_number) => {
             view_container.set_current_view_from_index (page_number);
@@ -529,7 +529,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         GLib.Application.get_default ().send_notification (context, notification);
     }
 
-    public async void show_notification_from_media_async (Media media) {
+    private async void show_notification_from_media_async (Media media) {
         if (media == null)
             return;
 
@@ -558,7 +558,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     /**
      * Sets the given view as the active item
      */
-    public void set_active_view (ViewWrapper view) {
+    private void set_active_view (ViewWrapper view) {
         if (!initialization_finished)
             return;
 
@@ -602,7 +602,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
      * SourceList Configuration
      */
 
-    public void update_badge_on_playlist_update (Playlist p, SourceListEntry entry) {
+    private void update_badge_on_playlist_update (Playlist p, SourceListEntry entry) {
         p.media_added.connect((s) => { update_playlist_badge (p); });
         p.media_removed.connect((s) => { update_playlist_badge (p); });
         p.cleared.connect((s) => { update_playlist_badge (p); });
@@ -621,7 +621,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
 
     private bool update_sensitivities_pending = false;
 
-    public async void update_sensitivities () {
+    private async void update_sensitivities () {
         if (update_sensitivities_pending)
             return;
 
@@ -726,7 +726,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         library.add_playlist(playlist);
     }
 
-    public void show_playlist_view (Playlist p) {
+    private void show_playlist_view (Playlist p) {
         if (match_playlists.has_key (p)) {
             source_list_view.selected = match_playlist_entry.get (p);
             set_active_view ((Noise.ViewWrapper)view_container.get_view (match_playlists.get (p)));
@@ -871,7 +871,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
      * XXX: this doesn't belong here, but to the playback manager
      * @param s The media that is now playing
      */
-    public void media_played (Media m) {
+    private void media_played (Media m) {
         //reset the media position
         top_display.update_media ();
 
@@ -1011,7 +1011,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         }
     }
 
-    public void editPreferencesClick () {
+    private void editPreferencesClick () {
         if (preferences == null)
             preferences = new PreferencesWindow ();
         preferences.show_all ();
@@ -1094,15 +1094,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         }
     }
 
-    public void media_not_found(int id) {
-// XXX FIXME TODO Don't depend on ids
-#if 0
-        var not_found = new FileNotFoundDialog(library_manager, this, id);
-        not_found.show ();
-#endif
-    }
-
-    public void search_entry_activate () {
+    private void search_entry_activate () {
         var vw = view_container.get_current_view ();
 
         if (vw != null && vw is ViewWrapper) {


### PR DESCRIPTION
Several methods were marked as public but only used in this class

`media_not_found` was never used at all