### PR TITLE
TimeUtils.vala: Remove dead code

### DIFF
--- a/core/Utils/TimeUtils.vala
+++ b/core/Utils/TimeUtils.vala
@@ -29,124 +29,13 @@
 namespace Noise.TimeUtils {
     public const uint64 NANO_INV = 1000000000;
     public const uint64 MILI_INV = 1000;
-    public const uint64 SEC_INV = 1;
-
-    public const uint SECONDS_PER_MINUTE = 60;
-    public const uint SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE;
-    public const uint SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR;
-
-    /**
-     * Receives the number of seconds and returns a string with format:
-     * "%i days, %i hours and %i minutes", "%i seconds", "%i minutes and %i seconds",
-     * or similar.
-     */
-    public inline string time_string_from_seconds (uint given_seconds) {
-        uint days = given_seconds / 86400;
-        uint hours = (given_seconds - days * 86400) / 3600;
-        uint minutes = (given_seconds - days * 86400 - hours * 3600) / 60;
-        uint seconds = given_seconds - days * 86400 - hours * 3600 - minutes * 60;
-
-        if (given_seconds < SECONDS_PER_MINUTE)
-            return ngettext ("%u second", "%u seconds", seconds).printf (seconds);
-
-        string days_string = "", hours_string = "", minutes_string = "", seconds_string = "";
-
-        // If less than one hour, show minutes + seconds
-        if (given_seconds < SECONDS_PER_HOUR) {
-            minutes_string = ngettext ("%u minute", "%u minutes", minutes).printf (minutes);
-
-            if (seconds > 0) {
-                seconds_string = ngettext ("%u second", "%u seconds", seconds).printf (seconds);
-                /// Minutes and seconds
-                return C_("minutes and seconds", "%s and %s").printf (minutes_string, seconds_string);
-            }
-
-            return minutes_string;
-        }
-
-        if (days > 0)
-            days_string = ngettext ("%u day", "%u days", days).printf (days);
-
-        if (hours > 0)
-            hours_string = ngettext ("%u hour", "%u hours", hours).printf (hours);
-
-        if (minutes > 0)
-            minutes_string = ngettext ("%u minute", "%u minutes", minutes).printf (minutes);
-
-        string rv = "";
-
-        if (days > 0) {
-            if (hours > 0) {
-                if (minutes > 0)
-                    /// days, hours and minutes
-                    rv = C_("days, hours and minutes", "%s, %s and %s").printf (days_string, hours_string, minutes_string);
-                else
-                    /// days and hours
-                    rv = C_("days and hours", "%s and %s").printf (days_string, hours_string);
-            }
-            else {
-                if (minutes > 0)
-                    /// days and minutes
-                    rv = C_("days and minutes", "%s and %s").printf (days_string, minutes_string);
-                else
-                    rv = days_string;
-            }
-        }
-        else {
-            if (hours > 0) {
-                if (minutes > 0)
-                    /// hours and minutes
-                    rv = C_("hours and minutes", "%s and %s").printf (hours_string, minutes_string);
-                else
-                    rv = hours_string;
-            }
-            else {
-                // In theory, this will never be reached, since we handle it at the beginning.
-                rv = minutes_string;
-                warning ("Minutes string '%s'. Should not be reached", rv);
-            }
-        }
-
-        return rv;
-    }
-
-    public inline string time_string_from_miliseconds (uint64 miliseconds) {
-        return time_string_from_seconds ((uint)(miliseconds / MILI_INV));
-    }
-
-    public inline string time_string_from_nanoseconds (uint64 nanoseconds) {
-        return time_string_from_seconds ((uint)(nanoseconds / NANO_INV));
-    }
-
-    /**
-     * Receives the number of seconds and returns a string with format MM:SS
-     */
-    public inline string pretty_length (uint seconds) {
-        if (seconds < SECONDS_PER_HOUR) {
-            uint minutes = seconds / 60;
-            seconds -= minutes * 60;
-            return "%u:%02u".printf (minutes, seconds);
-        }
-
-        uint hours = seconds / 3600;
-        seconds -= hours * 3600;
-        uint minutes = seconds / 60;
-        seconds -= minutes * 60;
-        return "%u:%02u:%02u".printf (hours, minutes, seconds);
-    }
+    private const uint64 SEC_INV = 1;
 
     /**
      * Receives the number of miliseconds and returns a string with format MM:SS
      */
     public inline string pretty_length_from_ms (uint64 mseconds) {
-        return pretty_length ((uint)(mseconds / MILI_INV));
-    }
-
-    /**
-     * Receives the number of nanoseconds and returns a string with format MM:SS
-     */
-    public inline string pretty_length_from_ns (uint64 nseconds) {
-        return pretty_length ((uint)(nseconds / NANO_INV));
+        return Granite.DateTime.seconds_to_time ((int)(mseconds / MILI_INV));
     }
 
     /**
@@ -156,11 +45,6 @@ namespace Noise.TimeUtils {
         /// Format of date strings. See reference documentation of g_date_time_format()
         /// for more details.
         return dt.format (_("%m/%e/%Y %l:%M %p"));
-    }
-
-    public inline string pretty_timestamp_from_uint (uint time) {
-        var dt = Time.local (time);
-        return pretty_timestamp_from_time (dt);
     }
 
     /**
@@ -173,10 +57,6 @@ namespace Noise.TimeUtils {
      */
     public inline uint nanoseconds_to_miliseconds (uint64 nanoseconds) {
         return (uint) (nanoseconds * MILI_INV / NANO_INV);
-    }
-
-    public inline uint64 miliseconds_to_nanoseconds (uint miliseconds) {
-        return (uint64) miliseconds * NANO_INV / MILI_INV;
     }
 
     public inline uint nanoseconds_to_seconds (uint64 nanoseconds) {


### PR DESCRIPTION
* Remove a bunch of unused time utils code
* Use Granite.DateTime.seconds_to_time
* `SEC_INV` is only used here, so make it private