### PR TITLE
Show remove button

### DIFF
--- a/src/Dialogs/SmartPlaylistEditor.vala
+++ b/src/Dialogs/SmartPlaylistEditor.vala
@@ -303,6 +303,7 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
             field_changed (false);
 
             remove_button.clicked.connect (remove_clicked);
+            remove_button.show ();
             field_combobox.changed.connect (() => {field_changed (true);});
         }
 


### PR DESCRIPTION
this minimal commit brings the remove button back, but doesn't perform any fancy styling or have any refactoring.