### PR TITLE
No more video playback

### DIFF
--- a/core/GStreamer/Pipeline.vala
+++ b/core/GStreamer/Pipeline.vala
@@ -37,6 +37,8 @@ public class Noise.Pipeline : GLib.Object {
     public dynamic Gst.Element audiosinkqueue;
     public dynamic Gst.Element eq_audioconvert;
     public dynamic Gst.Element eq_audioconvert2;
+    
+    public dynamic Gst.Element fake;
 
     public dynamic Gst.Element playbin;
     public dynamic Gst.Element audiotee;
@@ -47,6 +49,9 @@ public class Noise.Pipeline : GLib.Object {
 
         pipe = new Gst.Pipeline("pipeline");
         playbin = Gst.ElementFactory.make ("playbin", "play");
+        
+        fake = Gst.ElementFactory.make ("fakesink", "fake");
+        playbin.set ("video-sink", fake );
 
         audiosink = Gst.ElementFactory.make("autoaudiosink", "audio-sink");
 


### PR DESCRIPTION
This really does fix #242 I couldn't null out the video sink in our playbin, but I could substitute in a fakesink. If this is totally bonkers then feel free to delete this pull request. technically you _can_ playback a video, but no playback window opens and you can't get into an undefined state by closing the window.