### PR TITLE
Simplify ViewContainer as ViewStack

### DIFF
--- a/plugins/Devices/CDRom/CDRomDevice.vala
+++ b/plugins/Devices/CDRom/CDRomDevice.vala
@@ -294,7 +294,7 @@ public class Noise.Plugins.CDRomDevice : GLib.Object, Noise.Device {
             if (media_being_ripped != s || media_being_ripped == null)
                 return false;
 
-            var wrapper = App.main_window.view_container.visible_child as DeviceViewWrapper;
+            var wrapper = App.main_window.view_stack.visible_child as DeviceViewWrapper;
 
             if (wrapper != null) {
                 if (wrapper.d == this)

--- a/plugins/Devices/CDRom/CDRomDevice.vala
+++ b/plugins/Devices/CDRom/CDRomDevice.vala
@@ -294,7 +294,7 @@ public class Noise.Plugins.CDRomDevice : GLib.Object, Noise.Device {
             if (media_being_ripped != s || media_being_ripped == null)
                 return false;
 
-            var wrapper = App.main_window.view_container.get_current_view () as DeviceViewWrapper;
+            var wrapper = App.main_window.view_container.visible_child as DeviceViewWrapper;
 
             if (wrapper != null) {
                 if (wrapper.d == this)

--- a/plugins/LastFM/LastFM.vala
+++ b/plugins/LastFM/LastFM.vala
@@ -93,7 +93,7 @@ namespace Noise.Plugins {
 
         private void source_list_added (GLib.Object o, int view_number) {
             if (o == LastFM.Core.get_default ().get_similar_playlist ()) {
-                var view = (Noise.PlaylistViewWrapper) App.main_window.view_container.get_child_by_name (view_number.to_string ());
+                var view = (Noise.PlaylistViewWrapper) App.main_window.view_stack.get_child_by_name (view_number.to_string ());
                 view.set_no_media_alert_message (_("No similar songs found"), _("There are no songs similar to the current song in your library. Make sure all song info is correct and you are connected to the Internet. Some songs may not have matches."));
             }
         }

--- a/plugins/LastFM/LastFM.vala
+++ b/plugins/LastFM/LastFM.vala
@@ -93,7 +93,7 @@ namespace Noise.Plugins {
 
         private void source_list_added (GLib.Object o, int view_number) {
             if (o == LastFM.Core.get_default ().get_similar_playlist ()) {
-                var view = (Noise.PlaylistViewWrapper) App.main_window.view_container.get_view (view_number);
+                var view = (Noise.PlaylistViewWrapper) App.main_window.view_container.get_child_by_name (view_number.to_string ());
                 view.set_no_media_alert_message (_("No similar songs found"), _("There are no songs similar to the current song in your library. Make sure all song info is correct and you are connected to the Internet. Some songs may not have matches."));
             }
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CLIENT_SOURCE
     GStreamer/GStreamerTagger.vala
     GStreamer/CoverImport.vala
     GStreamer/Streamer.vala
-    Views/ViewContainer.vala
+    Views/ViewStack.vala
     Views/Wrappers/ViewWrapper.vala
     Views/Wrappers/MusicViewWrapper.vala
     Views/Wrappers/DeviceViewWrapper.vala

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -275,7 +275,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     private void connect_to_sourcelist_signals () {
 
         source_list_view.selection_changed.connect ((page_number) => {
-            view_stack.set_current_view_from_index (page_number);
+            view_stack.visible_child_name = page_number.to_string ();
         });
 
         source_list_view.activated.connect ( () => {

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -36,7 +36,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     public bool newly_created_playlist { get; set; default = false; }
 
     public SourceListView source_list_view { get; private set; }
-    public ViewContainer view_container { get; private set; }
+    public ViewStack view_stack { get; private set; }
     public Widgets.ViewSelector view_selector { get; private set; }
     public Gtk.SearchEntry search_entry { get; private set; }
     public Widgets.StatusBar statusbar { get; private set; }
@@ -249,7 +249,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         headerbar.set_custom_title (top_display);
         headerbar.show_all ();
 
-        view_container = new ViewContainer ();
+        view_stack = new ViewStack ();
         source_list_view = new SourceListView ();
 
         statusbar = new Widgets.StatusBar ();
@@ -261,7 +261,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
 
         main_hpaned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         main_hpaned.pack1 (grid, false, false);
-        main_hpaned.pack2 (view_container, true, false);
+        main_hpaned.pack2 (view_stack, true, false);
         main_hpaned.show_all ();
 
         saved_state_settings.bind ("sidebar-width", main_hpaned, "position", GLib.SettingsBindFlags.DEFAULT);
@@ -275,7 +275,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     private void connect_to_sourcelist_signals () {
 
         source_list_view.selection_changed.connect ((page_number) => {
-            view_container.set_current_view_from_index (page_number);
+            view_stack.set_current_view_from_index (page_number);
         });
 
         source_list_view.activated.connect ( () => {
@@ -283,7 +283,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.item_action_activated.connect ((page_number) => {
-            var view = view_container.get_child_by_name (page_number.to_string ());
+            var view = view_stack.get_child_by_name (page_number.to_string ());
             if (view is DeviceView) {
                 ((DeviceView) view).device.eject ();
             }
@@ -291,7 +291,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         source_list_view.edited.connect (playlist_name_edited);
 
         source_list_view.playlist_rename_clicked.connect ((page_number) => {
-            var view = view_container.get_child_by_name (page_number.to_string ());
+            var view = view_stack.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 search_field_has_focus = false;
                 source_list_view.start_editing_item(source_list_view.selected);
@@ -299,7 +299,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_edit_clicked.connect ((page_number) => {
-            var view = view_container.get_child_by_name (page_number.to_string ());
+            var view = view_stack.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var p = ((PlaylistViewWrapper)view).playlist;
                 if (p is SmartPlaylist) {
@@ -309,7 +309,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_remove_clicked.connect ((page_number) => {
-            var view = view_container.get_child_by_name (page_number.to_string ());
+            var view = view_stack.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var playlistview = (PlaylistViewWrapper)view;
                 if (playlistview.hint == ViewWrapper.Hint.PLAYLIST) {
@@ -357,7 +357,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_remove_clicked.connect ((page_number) => {
-            var view = view_container.get_child_by_name (page_number.to_string ());
+            var view = view_stack.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var playlistview = (PlaylistViewWrapper)view;
                 if (playlistview.hint == ViewWrapper.Hint.PLAYLIST) {
@@ -369,7 +369,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_save_clicked.connect ((page_number) => {
-            var view = view_container.get_child_by_name (page_number.to_string ());
+            var view = view_stack.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var playlistview = (PlaylistViewWrapper)view;
                 if (playlistview.hint != ViewWrapper.Hint.READ_ONLY_PLAYLIST)
@@ -385,7 +385,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_export_clicked.connect ((page_number) => {
-            var view = view_container.get_child_by_name (page_number.to_string ());
+            var view = view_stack.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var playlistview = (PlaylistViewWrapper)view;
                 switch (playlistview.hint) {
@@ -401,7 +401,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_media_added.connect ((page_number, uris) => {
-            var view = view_container.get_child_by_name (page_number.to_string ());
+            var view = view_stack.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var playlistview = (PlaylistViewWrapper) view;
                 if (playlistview.hint == ViewWrapper.Hint.PLAYLIST) {
@@ -561,7 +561,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         if (!initialization_finished)
             return;
 
-        view_container.set_current_view (view);
+        view_stack.set_current_view (view);
 
         if (view is ViewWrapper)
             (view as ViewWrapper).set_as_current_view ();
@@ -584,7 +584,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         // Add Music Library View
         var music_tvs = new TreeViewSetup (ViewWrapper.Hint.MUSIC, "library:main", library_manager.connection);
         var music_view_wrapper = new MusicViewWrapper (music_tvs, library_manager, top_display);
-        int view_number = view_container.add_view (music_view_wrapper);
+        int view_number = view_stack.add_view (music_view_wrapper);
         var entry = source_list_view.add_item (view_number, _("Music"), ViewWrapper.Hint.MUSIC, new ThemedIcon ("library-music"));
         match_playlist_entry.set (library_manager.p_music, entry);
         match_playlists.set (library_manager.p_music, view_number);
@@ -664,11 +664,11 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         int page_number = match_devices.get (device.get_unique_identifier ());
 
         foreach (int number in source_list_view.remove_device (page_number)) {
-            view_container.remove_view (view_container.get_child_by_name (number.to_string ()));
+            view_stack.remove_view (view_stack.get_child_by_name (number.to_string ()));
         }
 
         match_devices.unset (device.get_unique_identifier ());
-        view_container.remove_view (view_container.get_child_by_name (page_number.to_string ()));
+        view_stack.remove_view (view_stack.get_child_by_name (page_number.to_string ()));
     }
 
     private void create_device_source_list (Device d) {
@@ -676,7 +676,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
             SourceListEntry? entry;
             var pref = library_manager.get_preferences_for_device (d);
             var dv = new DeviceView (d, pref);
-            int view_number = view_container.add_view (dv);
+            int view_number = view_stack.add_view (dv);
             match_devices.set (d.get_unique_identifier (), view_number);
             if (d.only_use_custom_view ()) {
                 message("new custom device (probably a CD) added with %d songs.\n", d.get_library ().get_medias ().size);
@@ -687,7 +687,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
                 var tvs = new TreeViewSetup (ViewWrapper.Hint.DEVICE_AUDIO);
                 var music_view_wrapper = new DeviceViewWrapper(tvs, d, d.get_library ());
 
-                int subview_number = view_container.add_view (music_view_wrapper);
+                int subview_number = view_stack.add_view (music_view_wrapper);
                 entry = source_list_view.add_item  (view_number, d.getDisplayName (), ViewWrapper.Hint.DEVICE, d.get_icon (), new ThemedIcon ("media-eject-symbolic"), null, d);
                 source_list_view.add_item (subview_number, _("Music"), ViewWrapper.Hint.DEVICE_AUDIO, new ThemedIcon ("library-music"), null, entry as SourceListExpandableItem, d);
                 if (d.get_library ().support_playlists () == true) {
@@ -716,7 +716,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
             match_playlists.unset (playlist);
         }
 
-        view_container.remove_view (view_container.get_child_by_name (page_number.to_string ()));
+        view_stack.remove_view (view_stack.get_child_by_name (page_number.to_string ()));
     }
 
     public void create_new_playlist (Library? library = library_manager) {
@@ -729,7 +729,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     private void show_playlist_view (Playlist p) {
         if (match_playlists.has_key (p)) {
             source_list_view.selected = match_playlist_entry.get (p);
-            set_active_view ((Noise.ViewWrapper) view_container.get_child_by_name (match_playlists.get (p).to_string ()));
+            set_active_view ((Noise.ViewWrapper) view_stack.get_child_by_name (match_playlists.get (p).to_string ()));
         }
     }
 
@@ -751,7 +751,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         }
 
         var view = new PlaylistViewWrapper (p, hint, tvs, library);
-        var view_number = view_container.add_view (view);
+        var view_number = view_stack.add_view (view);
         var entry = source_list_view.add_item (view_number, p.name, hint, p.icon, null, into_expandable);
         if (p.show_badge == true) {
             update_badge_on_playlist_update (p, entry);
@@ -797,12 +797,12 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
             match_playlists.unset (smartplaylist);
         }
 
-        view_container.remove_view (view_container.get_child_by_name (page_number.to_string ()));
+        view_stack.remove_view (view_stack.get_child_by_name (page_number.to_string ()));
     }
 
     private void playlist_name_edited (int page_number, string new_name) {
         search_field_has_focus = true;
-        var unparsed_view = view_container.get_child_by_name (page_number.to_string ());
+        var unparsed_view = view_stack.get_child_by_name (page_number.to_string ());
         if (unparsed_view is PlaylistViewWrapper) {
             var view = unparsed_view as PlaylistViewWrapper;
             if (view.hint == ViewWrapper.Hint.PLAYLIST || view.hint == ViewWrapper.Hint.READ_ONLY_PLAYLIST || view.hint == ViewWrapper.Hint.SMART_PLAYLIST) {
@@ -833,7 +833,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
             }
         });
 
-        var view_number = view_container.add_view (view);
+        var view_number = view_stack.add_view (view);
         var entry = source_list_view.add_item  (view_number, p.name, ViewWrapper.Hint.SMART_PLAYLIST, p.icon);
         p.updated.connect ((old_name) => {
             if (old_name != null)
@@ -1094,7 +1094,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     }
 
     private void search_entry_activate () {
-        var vw = view_container.visible_child;
+        var vw = view_stack.visible_child;
 
         if (vw != null && vw is ViewWrapper) {
             (vw as ViewWrapper).play_first_media ();

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -561,7 +561,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         if (!initialization_finished)
             return;
 
-        view_stack.set_current_view (view);
+        view_stack.visible_child = view;
 
         if (view is ViewWrapper)
             (view as ViewWrapper).set_as_current_view ();

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -283,7 +283,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.item_action_activated.connect ((page_number) => {
-            var view = view_container.get_view (page_number);
+            var view = view_container.get_child_by_name (page_number.to_string ());
             if (view is DeviceView) {
                 ((DeviceView) view).device.eject ();
             }
@@ -291,7 +291,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         source_list_view.edited.connect (playlist_name_edited);
 
         source_list_view.playlist_rename_clicked.connect ((page_number) => {
-            var view = view_container.get_view (page_number);
+            var view = view_container.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 search_field_has_focus = false;
                 source_list_view.start_editing_item(source_list_view.selected);
@@ -299,7 +299,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_edit_clicked.connect ((page_number) => {
-            var view = view_container.get_view (page_number);
+            var view = view_container.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var p = ((PlaylistViewWrapper)view).playlist;
                 if (p is SmartPlaylist) {
@@ -309,7 +309,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_remove_clicked.connect ((page_number) => {
-            var view = view_container.get_view (page_number);
+            var view = view_container.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var playlistview = (PlaylistViewWrapper)view;
                 if (playlistview.hint == ViewWrapper.Hint.PLAYLIST) {
@@ -357,7 +357,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_remove_clicked.connect ((page_number) => {
-            var view = view_container.get_view (page_number);
+            var view = view_container.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var playlistview = (PlaylistViewWrapper)view;
                 if (playlistview.hint == ViewWrapper.Hint.PLAYLIST) {
@@ -369,7 +369,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_save_clicked.connect ((page_number) => {
-            var view = view_container.get_view (page_number);
+            var view = view_container.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var playlistview = (PlaylistViewWrapper)view;
                 if (playlistview.hint != ViewWrapper.Hint.READ_ONLY_PLAYLIST)
@@ -385,7 +385,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_export_clicked.connect ((page_number) => {
-            var view = view_container.get_view (page_number);
+            var view = view_container.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var playlistview = (PlaylistViewWrapper)view;
                 switch (playlistview.hint) {
@@ -401,7 +401,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         });
 
         source_list_view.playlist_media_added.connect ((page_number, uris) => {
-            var view = view_container.get_view (page_number);
+            var view = view_container.get_child_by_name (page_number.to_string ());
             if (view is PlaylistViewWrapper) {
                 var playlistview = (PlaylistViewWrapper) view;
                 if (playlistview.hint == ViewWrapper.Hint.PLAYLIST) {
@@ -664,11 +664,11 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         int page_number = match_devices.get (device.get_unique_identifier ());
 
         foreach (int number in source_list_view.remove_device (page_number)) {
-            view_container.remove_view (view_container.get_view (number));
+            view_container.remove_view (view_container.get_child_by_name (number.to_string ()));
         }
 
         match_devices.unset (device.get_unique_identifier ());
-        view_container.remove_view (view_container.get_view (page_number));
+        view_container.remove_view (view_container.get_child_by_name (page_number.to_string ()));
     }
 
     private void create_device_source_list (Device d) {
@@ -716,7 +716,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
             match_playlists.unset (playlist);
         }
 
-        view_container.remove_view (view_container.get_view (page_number));
+        view_container.remove_view (view_container.get_child_by_name (page_number.to_string ()));
     }
 
     public void create_new_playlist (Library? library = library_manager) {
@@ -729,7 +729,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     private void show_playlist_view (Playlist p) {
         if (match_playlists.has_key (p)) {
             source_list_view.selected = match_playlist_entry.get (p);
-            set_active_view ((Noise.ViewWrapper)view_container.get_view (match_playlists.get (p)));
+            set_active_view ((Noise.ViewWrapper) view_container.get_child_by_name (match_playlists.get (p).to_string ()));
         }
     }
 
@@ -797,12 +797,12 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
             match_playlists.unset (smartplaylist);
         }
 
-        view_container.remove_view (view_container.get_view (page_number));
+        view_container.remove_view (view_container.get_child_by_name (page_number.to_string ()));
     }
 
     private void playlist_name_edited (int page_number, string new_name) {
         search_field_has_focus = true;
-        var unparsed_view = view_container.get_view (page_number);
+        var unparsed_view = view_container.get_child_by_name (page_number.to_string ());
         if (unparsed_view is PlaylistViewWrapper) {
             var view = unparsed_view as PlaylistViewWrapper;
             if (view.hint == ViewWrapper.Hint.PLAYLIST || view.hint == ViewWrapper.Hint.READ_ONLY_PLAYLIST || view.hint == ViewWrapper.Hint.SMART_PLAYLIST) {

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -1094,7 +1094,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     }
 
     private void search_entry_activate () {
-        var vw = view_container.get_current_view ();
+        var vw = view_container.visible_child;
 
         if (vw != null && vw is ViewWrapper) {
             (vw as ViewWrapper).play_first_media ();

--- a/src/Views/ListView/Lists/GenericList.vala
+++ b/src/Views/ListView/Lists/GenericList.vala
@@ -309,7 +309,7 @@ public abstract class Noise.GenericList : FastView {
 
         // order the queue like this list
         var queue_view_id = App.main_window.match_playlists[App.player.queue_playlist];
-        var view = (ViewWrapper) App.main_window.view_container.get_child_by_name (queue_view_id.to_string ());
+        var view = (ViewWrapper) App.main_window.view_stack.get_child_by_name (queue_view_id.to_string ());
         view.list_view.list_view.set_sort_column_id (tvs.sort_column_id, tvs.sort_direction);
 
         media_played.begin (App.player.current_media);

--- a/src/Views/ListView/Lists/GenericList.vala
+++ b/src/Views/ListView/Lists/GenericList.vala
@@ -309,7 +309,7 @@ public abstract class Noise.GenericList : FastView {
 
         // order the queue like this list
         var queue_view_id = App.main_window.match_playlists[App.player.queue_playlist];
-        var view = (ViewWrapper) App.main_window.view_container.get_view (queue_view_id);
+        var view = (ViewWrapper) App.main_window.view_container.get_child_by_name (queue_view_id.to_string ());
         view.list_view.list_view.set_sort_column_id (tvs.sort_column_id, tvs.sort_direction);
 
         media_played.begin (App.player.current_media);

--- a/src/Views/ViewContainer.vala
+++ b/src/Views/ViewContainer.vala
@@ -54,10 +54,6 @@ public class Noise.ViewContainer : Gtk.Stack {
         view.destroy ();
     }
 
-    public Gtk.Widget? get_view (int index) {
-        return get_child_by_name (index.to_string ());
-    }
-
     /**
      * Tries to set the given view as current.
      * @return false if fails.

--- a/src/Views/ViewContainer.vala
+++ b/src/Views/ViewContainer.vala
@@ -58,23 +58,6 @@ public class Noise.ViewContainer : Gtk.Stack {
         return get_child_by_name (index.to_string ());
     }
 
-    public Gtk.Widget? get_nth_page (int index) {
-        return get_view (index);
-    }
-
-    public int get_current_index () {
-        return int.parse (visible_child_name);
-    }
-
-    public Gtk.Widget? get_current_view () {
-        return visible_child;
-    }
-
-    public uint get_n_pages ()
-    {
-        return get_children ().length ();
-    }
-
     /**
      * Tries to set the given view as current.
      * @return false if fails.
@@ -109,7 +92,7 @@ public class Noise.ViewContainer : Gtk.Stack {
         return true;
     }
 
-    void update_visible () {
+    private void update_visible () {
         if (visible_child == null)
             return;
 

--- a/src/Views/ViewStack.vala
+++ b/src/Views/ViewStack.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2012-2017 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2012-2018 elementary LLC. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/Views/ViewStack.vala
+++ b/src/Views/ViewStack.vala
@@ -63,16 +63,6 @@ public class Noise.ViewStack : Gtk.Stack {
     }
 
     /**
-     * Tries to set the given view as current.
-     * @return false if fails.
-     */
-    public bool set_current_view (Gtk.Widget view) {
-        visible_child = view;
-
-        return true;
-    }
-
-    /**
      * Tries to set the given view index as current.
      * @return false if fails.
      */

--- a/src/Views/ViewStack.vala
+++ b/src/Views/ViewStack.vala
@@ -29,8 +29,16 @@
 public class Noise.ViewStack : Gtk.Stack {
     private int nextview_number { get; set; default=0; }
 
-    public ViewStack () {
+    construct {
         expand = true;
+
+        this.notify["visible-child"].connect (() => {
+            if (visible_child == null) {
+                critical ("Cannot set view as current view");
+            }
+
+            update_visible ();
+        });
     }
 
     /**
@@ -61,13 +69,6 @@ public class Noise.ViewStack : Gtk.Stack {
     public bool set_current_view (Gtk.Widget view) {
         visible_child = view;
 
-        if (visible_child == null) {
-            critical ("Cannot set view as current view");
-            return false;
-        }
-
-        update_visible ();
-
         return true;
     }
 
@@ -77,13 +78,6 @@ public class Noise.ViewStack : Gtk.Stack {
      */
     public bool set_current_view_from_index (int index) {
         visible_child_name = index.to_string ();
-
-        if (visible_child == null) {
-            critical ("Cannot set view index %i as current view", index);
-            return false;
-        }
-
-        update_visible ();
 
         return true;
     }

--- a/src/Views/ViewStack.vala
+++ b/src/Views/ViewStack.vala
@@ -26,10 +26,10 @@
  * Authored by: Victor Eduardo <victoreduardm@gmail.com>
  */
 
-public class Noise.ViewContainer : Gtk.Stack {
+public class Noise.ViewStack : Gtk.Stack {
     private int nextview_number { get; set; default=0; }
 
-    public ViewContainer () {
+    public ViewStack () {
         expand = true;
     }
 

--- a/src/Views/ViewStack.vala
+++ b/src/Views/ViewStack.vala
@@ -27,7 +27,7 @@
  */
 
 public class Noise.ViewStack : Gtk.Stack {
-    private int nextview_number { get; set; default=0; }
+    private int nextview_number { get; set; default = 0; }
 
     construct {
         expand = true;
@@ -35,9 +35,9 @@ public class Noise.ViewStack : Gtk.Stack {
         this.notify["visible-child"].connect (() => {
             if (visible_child == null) {
                 critical ("Cannot set view as current view");
+            } else {
+                update_visible ();
             }
-
-            update_visible ();
         });
     }
 
@@ -62,20 +62,7 @@ public class Noise.ViewStack : Gtk.Stack {
         view.destroy ();
     }
 
-    /**
-     * Tries to set the given view index as current.
-     * @return false if fails.
-     */
-    public bool set_current_view_from_index (int index) {
-        visible_child_name = index.to_string ();
-
-        return true;
-    }
-
     private void update_visible () {
-        if (visible_child == null)
-            return;
-
         if (visible_child is ViewWrapper) {
             ((ViewWrapper) visible_child).set_as_current_view ();
         } else if (visible_child is Gtk.Grid) {

--- a/src/Views/Wrappers/ViewWrapper.vala
+++ b/src/Views/Wrappers/ViewWrapper.vala
@@ -79,7 +79,7 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
 
     protected ViewType current_view {
         get {
-            var view = view_container.visible_child;
+            var view = view_stack.visible_child;
 
             if (view == grid_view)
                 return ViewType.GRID;
@@ -108,7 +108,7 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
 
     public bool is_current_wrapper {
         get {
-            return (App.main_window.initialization_finished && App.main_window.view_container.visible_child == this);
+            return (App.main_window.initialization_finished && App.main_window.view_stack.visible_child == this);
         }
     }
 
@@ -122,7 +122,7 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
     protected const int VIEW_CONSTRUCT_PRIORITY = Priority.DEFAULT_IDLE - 10;
 
     private bool widgets_ready = false;
-    private ViewContainer view_container;
+    private ViewStack view_stack;
     private ViewType last_used_view = ViewType.NONE;
 
     // Whether a call to set_media() has been issues on this view. This is important.
@@ -136,8 +136,8 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
     construct {
         orientation = Gtk.Orientation.VERTICAL;
 
-        view_container = new ViewContainer ();
-        add (view_container);
+        view_stack = new ViewStack ();
+        add (view_stack);
 
         App.main_window.view_selector.mode_changed.connect (view_selector_changed);
         library.search_finished.connect (search_field_changed);
@@ -147,19 +147,19 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
      * Checks which views are available and packs them in (if they are not packed yet)
      */
     protected void pack_views () {
-        assert (view_container != null);
+        assert (view_stack != null);
 
-        if (has_grid_view && grid_view.parent != view_container)
-            view_container.add_view (grid_view);
+        if (has_grid_view && grid_view.parent != view_stack)
+            view_stack.add_view (grid_view);
 
-        if (has_list_view && list_view.parent != view_container)
-            view_container.add_view (list_view);
+        if (has_list_view && list_view.parent != view_stack)
+            view_stack.add_view (list_view);
 
-        if (has_welcome_screen && welcome_screen.parent != view_container)
-            view_container.add_view (welcome_screen);
+        if (has_welcome_screen && welcome_screen.parent != view_stack)
+            view_stack.add_view (welcome_screen);
 
-        if (has_embedded_alert && embedded_alert.parent != view_container)
-            view_container.add_view (embedded_alert);
+        if (has_embedded_alert && embedded_alert.parent != view_stack)
+            view_stack.add_view (embedded_alert);
 
         widgets_ready = true;
         show_all ();
@@ -177,7 +177,7 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
         switch (type) {
             case ViewType.LIST:
                 if (has_list_view) {
-                    successful = view_container.set_current_view (list_view);
+                    successful = view_stack.set_current_view (list_view);
                     list_view.list_view.scroll_to_current_media (true);
                 } else {
                     successful = false;
@@ -185,20 +185,20 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
                 break;
             case ViewType.GRID:
                 if (has_grid_view) {
-                    successful = view_container.set_current_view (grid_view);
+                    successful = view_stack.set_current_view (grid_view);
                 } else {
                     if (has_list_view) {
-                        successful = view_container.set_current_view (list_view);
+                        successful = view_stack.set_current_view (list_view);
                         list_view.list_view.scroll_to_current_media (true);
                     }
                     successful = false;
                 }
                 break;
             case ViewType.ALERT:
-                successful = view_container.set_current_view (embedded_alert);
+                successful = view_stack.set_current_view (embedded_alert);
                 break;
             case ViewType.WELCOME:
-                successful = view_container.set_current_view (welcome_screen);
+                successful = view_stack.set_current_view (welcome_screen);
                 break;
         }
 
@@ -369,10 +369,10 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
         else if (new_view == ViewType.GRID && has_grid_view)
             set_active_view (ViewType.GRID);
         else if (has_list_view) {
-            view_container.set_current_view (list_view);
+            view_stack.set_current_view (list_view);
             list_view.list_view.scroll_to_current_media (true);
         } else if (has_grid_view)
-            view_container.set_current_view (grid_view);
+            view_stack.set_current_view (grid_view);
     }
 
     /**

--- a/src/Views/Wrappers/ViewWrapper.vala
+++ b/src/Views/Wrappers/ViewWrapper.vala
@@ -177,7 +177,7 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
         switch (type) {
             case ViewType.LIST:
                 if (has_list_view) {
-                    successful = view_stack.set_current_view (list_view);
+                    view_stack.visible_child = list_view;
                     list_view.list_view.scroll_to_current_media (true);
                 } else {
                     successful = false;
@@ -185,20 +185,20 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
                 break;
             case ViewType.GRID:
                 if (has_grid_view) {
-                    successful = view_stack.set_current_view (grid_view);
+                    view_stack.visible_child = grid_view;
                 } else {
                     if (has_list_view) {
-                        successful = view_stack.set_current_view (list_view);
+                        view_stack.visible_child = list_view;
                         list_view.list_view.scroll_to_current_media (true);
                     }
                     successful = false;
                 }
                 break;
             case ViewType.ALERT:
-                successful = view_stack.set_current_view (embedded_alert);
+                view_stack.visible_child = embedded_alert;
                 break;
             case ViewType.WELCOME:
-                successful = view_stack.set_current_view (welcome_screen);
+                view_stack.visible_child = welcome_screen;
                 break;
         }
 
@@ -369,10 +369,10 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
         else if (new_view == ViewType.GRID && has_grid_view)
             set_active_view (ViewType.GRID);
         else if (has_list_view) {
-            view_stack.set_current_view (list_view);
+            view_stack.visible_child = list_view;
             list_view.list_view.scroll_to_current_media (true);
         } else if (has_grid_view)
-            view_stack.set_current_view (grid_view);
+            view_stack.visible_child = grid_view;
     }
 
     /**

--- a/src/Views/Wrappers/ViewWrapper.vala
+++ b/src/Views/Wrappers/ViewWrapper.vala
@@ -79,7 +79,7 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
 
     protected ViewType current_view {
         get {
-            var view = view_container.get_current_view ();
+            var view = view_container.visible_child;
 
             if (view == grid_view)
                 return ViewType.GRID;


### PR DESCRIPTION
* Rename as ViewStack so we know what widget this subclasses
* Use `visible_child` instead of a `get_current_view ()` method
* Use `get_child_by_name ()` instead of `get_view ()` method
* Use `visible_child` and `visible_child_name` instead of `set_view` methods
* Listen to `visible_child` and `update_visible` if it changes and isn't null.
* Remove the null check from `update_visible` since we check that in the notify.connect
* Removed unused methods