### PR TITLE
Port playback controls to GLib.Action

### DIFF
--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -48,7 +48,6 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     private bool media_half_played_sended { get; set; default = false; }
     private bool search_field_has_focus { get; set; default = true; }
 
-    private Gtk.Button play_button;
     private Gtk.Paned main_hpaned;
     private Cancellable notification_cancellable;
     private PreferencesWindow? preferences = null;
@@ -64,12 +63,14 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
 
     public const string ACTION_PREFIX = "win.";
     public const string ACTION_IMPORT = "action_import";
+    public const string ACTION_PLAY = "action_play";
     public const string ACTION_PLAY_NEXT = "action_play_next";
     public const string ACTION_PLAY_PREVIOUS = "action_play_previous";
     public const string ACTION_SEARCH = "action_search";
 
     private const ActionEntry[] action_entries = {
         { ACTION_IMPORT, action_import },
+        { ACTION_PLAY, action_play, null, "false" },
         { ACTION_PLAY_NEXT, action_play_next },
         { ACTION_PLAY_PREVIOUS, action_play_previous }
     };
@@ -234,7 +235,8 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         previous_button.action_name = ACTION_PREFIX + ACTION_PLAY_PREVIOUS;
         previous_button.tooltip_text = _("Previous");
 
-        play_button = new Gtk.Button.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        var play_button = new Gtk.Button.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        play_button.action_name = ACTION_PREFIX + ACTION_PLAY;
         play_button.tooltip_text = _("Play");
 
         var next_button = new Gtk.Button.from_icon_name ("media-skip-forward-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
@@ -285,6 +287,18 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
 
         add (main_hpaned);
         set_titlebar (headerbar);
+
+        actions.action_state_changed.connect ((name, new_state) => {
+            if (name == ACTION_PLAY) {
+                if (new_state.get_boolean () == false) {
+                    play_button.image = new Gtk.Image.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                    play_button.tooltip_text = _("Play");
+                } else {
+                    play_button.image = new Gtk.Image.from_icon_name ("media-playback-pause-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                    play_button.tooltip_text = _("Pause");
+                }
+            }
+        });
 
         connect_to_sourcelist_signals ();
     }
@@ -500,8 +514,6 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
             show_playlist_view (library_manager.p_music);
         }
 
-        play_button.clicked.connect (() => {play_media ();});
-
         search_entry.activate.connect (search_entry_activate);
         search_entry.search_changed.connect (() => {
             if (search_entry.text_length != 1) {
@@ -648,9 +660,8 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         bool media_active = App.player.current_media != null;
         bool media_available = App.player.get_current_media_list ().size > 0;
 
-        play_button.set_sensitive (media_active || media_available);
-
         ((SimpleAction) actions.lookup_action (ACTION_IMPORT)).set_enabled (!doing_ops && folder_set);
+        ((SimpleAction) actions.lookup_action (ACTION_PLAY)).set_enabled (media_active || media_available);
         ((SimpleAction) actions.lookup_action (ACTION_PLAY_NEXT)).set_enabled (media_active || media_available);
         ((SimpleAction) actions.lookup_action (ACTION_PLAY_PREVIOUS)).set_enabled (media_active || media_available);
 
@@ -658,8 +669,12 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         source_list_view.change_playlist_category_visibility (have_media);
         statusbar.playlist_menubutton_sensitive = folder_set && have_media;
 
-        if (!media_active || have_media && !App.player.playing)
-            play_button.set_image (new Gtk.Image.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR));
+        if (!media_active || have_media && !App.player.playing) {
+            ((SimpleAction) actions.lookup_action (ACTION_PLAY)).set_state (false);
+        } else {
+            ((SimpleAction) actions.lookup_action (ACTION_PLAY)).set_state (true);
+        }
+
     }
 
     /**
@@ -912,7 +927,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
 
 
     public virtual void playback_stopped (int64 was_playing) {
-        play_button.set_image (new Gtk.Image.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR));
+        ((SimpleAction) actions.lookup_action (ACTION_PLAY)).set_state (false);
         //reset some booleans
         media_considered_previewed = false;
         media_considered_played = false;
@@ -924,14 +939,12 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     }
 
     public virtual void playback_started () {
-        play_button.set_image (new Gtk.Image.from_icon_name ("media-playback-pause-symbolic", Gtk.IconSize.LARGE_TOOLBAR));
-        play_button.set_tooltip_text (_("Pause"));
+        ((SimpleAction) actions.lookup_action (ACTION_PLAY)).set_state (true);
         debug ("playback started");
     }
 
     public virtual void playback_paused () {
-        play_button.set_image (new Gtk.Image.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR));
-        play_button.set_tooltip_text (_("Play"));
+        ((SimpleAction) actions.lookup_action (ACTION_PLAY)).set_state (false);
         debug ("playback paused");
     }
 
@@ -1022,6 +1035,10 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         } else {
             debug("Can't add to library.. already doing file operations\n");
         }
+    }
+
+    private void action_play () {
+        play_media ();
     }
 
     private void action_play_next () {

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -66,7 +66,6 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     public const string ACTION_PLAY = "action_play";
     public const string ACTION_PLAY_NEXT = "action_play_next";
     public const string ACTION_PLAY_PREVIOUS = "action_play_previous";
-    public const string ACTION_SEARCH = "action_search";
 
     private const ActionEntry[] action_entries = {
         { ACTION_IMPORT, action_import },

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -48,10 +48,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     private bool media_half_played_sended { get; set; default = false; }
     private bool search_field_has_focus { get; set; default = true; }
 
-    private Gtk.Button previous_button;
     private Gtk.Button play_button;
-    private Gtk.Button next_button;
-    private Gtk.MenuItem import_menuitem;
     private Gtk.Paned main_hpaned;
     private Cancellable notification_cancellable;
     private PreferencesWindow? preferences = null;
@@ -63,7 +60,25 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     private Gee.HashMap<string, int> match_devices;
     private Gee.HashMap<unowned Playlist, SourceListEntry> match_playlist_entry;
 
+    public SimpleActionGroup actions { get; construct; }
+
+    public const string ACTION_PREFIX = "win.";
+    public const string ACTION_IMPORT = "action_import";
+    public const string ACTION_PLAY_NEXT = "action_play_next";
+    public const string ACTION_PLAY_PREVIOUS = "action_play_previous";
+    public const string ACTION_SEARCH = "action_search";
+
+    private const ActionEntry[] action_entries = {
+        { ACTION_IMPORT, action_import },
+        { ACTION_PLAY_NEXT, action_play_next },
+        { ACTION_PLAY_PREVIOUS, action_play_previous }
+    };
+
     construct {
+        actions = new SimpleActionGroup ();
+        actions.add_action_entries (action_entries, this);
+        insert_action_group ("win", actions);
+
         main_settings = Settings.Main.get_default ();
 
         library_manager.media_added.connect (update_sensitivities);
@@ -199,8 +214,8 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     }
 
     private inline void build_main_widgets () {
-        import_menuitem = new Gtk.MenuItem.with_label (_("Import to Library…"));
-        import_menuitem.activate.connect (fileImportMusicClick);
+        var import_menuitem = new Gtk.MenuItem.with_label (_("Import to Library…"));
+        import_menuitem.action_name = ACTION_PREFIX + ACTION_IMPORT;
 
         var preferences_menuitem = new Gtk.MenuItem.with_label (_("Preferences"));
         preferences_menuitem.activate.connect (editPreferencesClick);
@@ -215,13 +230,15 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         menu_button.image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR);
         menu_button.popup = menu;
 
-        previous_button = new Gtk.Button.from_icon_name ("media-skip-backward-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        var previous_button = new Gtk.Button.from_icon_name ("media-skip-backward-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        previous_button.action_name = ACTION_PREFIX + ACTION_PLAY_PREVIOUS;
         previous_button.tooltip_text = _("Previous");
 
         play_button = new Gtk.Button.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         play_button.tooltip_text = _("Play");
 
-        next_button = new Gtk.Button.from_icon_name ("media-skip-forward-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        var next_button = new Gtk.Button.from_icon_name ("media-skip-forward-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        next_button.action_name = ACTION_PREFIX + ACTION_PLAY_NEXT;
         next_button.tooltip_text = _("Next");
 
         search_entry = new Gtk.SearchEntry ();
@@ -483,9 +500,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
             show_playlist_view (library_manager.p_music);
         }
 
-        previous_button.clicked.connect (() => {play_previous_media ();});
         play_button.clicked.connect (() => {play_media ();});
-        next_button.clicked.connect (() => {play_next_media ();});
 
         search_entry.activate.connect (search_entry_activate);
         search_entry.search_changed.connect (() => {
@@ -631,14 +646,13 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         bool have_media = library_manager.get_medias ().size > 0;
         bool doing_ops = library_manager.doing_file_operations ();
         bool media_active = App.player.current_media != null;
-
-        import_menuitem.sensitive = !doing_ops && folder_set;
-
-        // Play, pause, ...
         bool media_available = App.player.get_current_media_list ().size > 0;
-        previous_button.set_sensitive (media_active || media_available);
+
         play_button.set_sensitive (media_active || media_available);
-        next_button.set_sensitive (media_active || media_available);
+
+        ((SimpleAction) actions.lookup_action (ACTION_IMPORT)).set_enabled (!doing_ops && folder_set);
+        ((SimpleAction) actions.lookup_action (ACTION_PLAY_NEXT)).set_enabled (media_active || media_available);
+        ((SimpleAction) actions.lookup_action (ACTION_PLAY_PREVIOUS)).set_enabled (media_active || media_available);
 
         // hide playlists when media list is empty
         source_list_view.change_playlist_category_visibility (have_media);
@@ -979,7 +993,7 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         }
     }
 
-    public virtual void fileImportMusicClick () {
+    public virtual void action_import () {
         if (!library_manager.doing_file_operations ()) {
 
             var folders = new Gee.TreeSet<string> ();
@@ -1008,6 +1022,14 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         } else {
             debug("Can't add to library.. already doing file operations\n");
         }
+    }
+
+    private void action_play_next () {
+        play_next_media ();
+    }
+
+    private void action_play_previous () {
+        play_previous_media ();
     }
 
     private void editPreferencesClick () {

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -101,8 +101,6 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         App.player.player.error_occured.connect (error_occured);
         App.player.media_played.connect_after (media_played);
         App.player.playback_stopped.connect (playback_stopped);
-        App.player.playback_started.connect (playback_started);
-        App.player.playback_paused.connect (playback_paused);
         App.player.changing_player.connect (() => {
             App.player.player.end_of_stream.disconnect (end_of_stream);
             App.player.player.current_position_update.disconnect (current_position_update);
@@ -936,16 +934,6 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         update_sensitivities.begin ();
 
         debug ("playback stopped");
-    }
-
-    public virtual void playback_started () {
-        ((SimpleAction) actions.lookup_action (ACTION_PLAY)).set_state (true);
-        debug ("playback started");
-    }
-
-    public virtual void playback_paused () {
-        ((SimpleAction) actions.lookup_action (ACTION_PLAY)).set_state (false);
-        debug ("playback paused");
     }
 
     public virtual void play_media (bool inhibit_notifications = false) {

--- a/src/PlaybackManager.vala
+++ b/src/PlaybackManager.vala
@@ -514,14 +514,14 @@ public class Noise.PlaybackManager : Object {
     public void start_playback () {
         player.play ();
         playing = true;
-
+        ((SimpleAction) App.main_window.actions.lookup_action (LibraryWindow.ACTION_PLAY)).set_state (true);
         playback_started ();
     }
 
     public void pause_playback () {
         player.pause ();
         playing = false;
-
+        ((SimpleAction) App.main_window.actions.lookup_action (LibraryWindow.ACTION_PLAY)).set_state (false);
         playback_paused ();
     }
 }

--- a/src/Views/Wrappers/MusicViewWrapper.vala
+++ b/src/Views/Wrappers/MusicViewWrapper.vala
@@ -129,7 +129,7 @@ public class Noise.MusicViewWrapper : ViewWrapper {
 
     private void welcome_screen_activated (int index) {
         if (index == 0) {
-            App.main_window.fileImportMusicClick ();
+            App.main_window.action_import ();
         } else if (index == 1) {
             if (!library.doing_file_operations ()) {
                 var file_chooser = new Gtk.FileChooserDialog (_("Select Music Folder"), App.main_window,


### PR DESCRIPTION
This branch ports the play/pause, next, and previous functions to GLib.Action. The reason I want to use GLib.Action here is because it allows us to reduce the amount of functions that are touching the UI. This makes it easier for us to move the whole headerbar into its own class in the future, which I think would be nice to break up this huge LibraryWindow class a little.

Since we don't have to touch the actual UI anymore when setting the playback action state, we can actually set this directly from the playback manager instead of having to listen for a signal in LibraryWindow.