### PR TITLE
SmartPlaylistEditor.vala: set own properties

### DIFF
--- a/src/Dialogs/SmartPlaylistEditor.vala
+++ b/src/Dialogs/SmartPlaylistEditor.vala
@@ -43,9 +43,13 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
     private Library library;
 
     public SmartPlaylistEditor (SmartPlaylist? sp = null, Library library) {
-        this.title = _("Smart Playlist Editor");
-        this.library = library;
-        this.deletable = false;
+        deletable = false;
+        destroy_with_parent = true;
+        title = _("Smart Playlist Editor");
+        library = library;
+        modal = true;
+        transient_for = App.main_window;
+        window_position = Gtk.WindowPosition.CENTER_ON_PARENT;
 
         if (sp == null) {
             is_new = true;
@@ -131,6 +135,8 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
         main_grid.attach (limiter_grid, 0, 6, 3, 1);
         main_grid.attach (button_box, 0, 7, 3, 1);
         ((Gtk.Container) get_content_area ()).add (main_grid);
+
+        load_smart_playlist ();
     }
 
     public void load_smart_playlist () {

--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -884,12 +884,6 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     public void show_smart_playlist_dialog (SmartPlaylist? smartplaylist = null) {
         SmartPlaylistEditor spe = null;
         spe = new SmartPlaylistEditor (smartplaylist, library_manager);
-        spe.window_position = Gtk.WindowPosition.CENTER;
-        spe.type_hint = Gdk.WindowTypeHint.DIALOG;
-        spe.set_transient_for (this);
-        spe.set_modal(true);
-        spe.destroy_with_parent = true;
-        spe.load_smart_playlist ();
         spe.show ();
     }
 


### PR DESCRIPTION
Dialog property changes from #265 

We don't need to set the type hint to Dialog here since this is a Gtk.Dialog subclass