### PR TITLE
 SmartPlaylistEditor.vala: Use GObject style

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: beat-box 0.3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-02-05 11:30-0800\n"
-"PO-Revision-Date: 2018-02-06 20:21+0000\n"
+"PO-Revision-Date: 2018-02-06 20:51+0000\n"
 "Last-Translator: Piotr Strebski <strebski@o2.pl>\n"
 "Language-Team: Polish "
 "<https://weblate.elementary.io/projects/music/music/pl/>\n"
@@ -438,16 +438,15 @@ msgid "Choose Music Folder"
 msgstr "Proszę wskazać katalog z muzyką"
 
 #: src/Dialogs/InstallGstreamerPluginsDialog.vala:38
-#, fuzzy, c-format
+#, c-format
 msgid "Would you like to install the %s plugin?"
-msgstr "Czy chciałbyś zainstalować wtyczkę %s?\n"
+msgstr "Czy chciałbyś zainstalować wtyczkę %s?"
 
 #: src/Dialogs/InstallGstreamerPluginsDialog.vala:39
-#, fuzzy, c-format
+#, c-format
 msgid "This song cannot be played. The %s plugin is required to play the song."
 msgstr ""
-"\n"
-"Ten utwór nie może zostać odtworzony. Do jego odtworzenia jest potrzebna "
+"Ten utwór nie może zostać odtworzony. Do jego odtworzenia potrzebna jest "
 "wtyczka %s."
 
 #: src/Dialogs/InstallGstreamerPluginsDialog.vala:52
@@ -791,11 +790,11 @@ msgid "kbps"
 msgstr "kb/s"
 
 #: src/Dialogs/SyncWarningDialog.vala:52
-#, fuzzy, c-format
+#, c-format
 msgid "Sync will remove %i item from %s"
 msgid_plural "Sync will remove %i items from %s"
-msgstr[0] "Synchronizacja usunie %i elementów z %s"
-msgstr[1] "Synchronizacja usunie %i elementów z %s"
+msgstr[0] "Synchronizacja usunie %i element z %s"
+msgstr[1] "Synchronizacja usunie %i elementy z %s"
 msgstr[2] "Synchronizacja usunie %i elementów z %s"
 
 #: src/Dialogs/SyncWarningDialog.vala:55

--- a/src/Dialogs/SmartPlaylistEditor.vala
+++ b/src/Dialogs/SmartPlaylistEditor.vala
@@ -123,17 +123,17 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
         if (smart_playlist != null) {
             name_entry.text = smart_playlist.name;
 
-            match_combobox.set_active (smart_playlist.conditional);
+            match_combobox.active = smart_playlist.conditional;
 
-            limit_check.set_active (smart_playlist.limit);
-            limit_spin.set_value ((double) smart_playlist.limit_amount);
+            limit_check.active = smart_playlist.limit;
+            limit_spin.value = (double) smart_playlist.limit_amount;
         } else {
             smart_playlist = new SmartPlaylist (library);
 
-            match_combobox.set_active (0);
+            match_combobox.active = 0;
 
-            limit_check.set_active (true);
-            limit_spin.set_value (50);
+            limit_check.active = true;
+            limit_spin.value = 50;
         }
 
         show_all ();

--- a/src/Dialogs/SmartPlaylistEditor.vala
+++ b/src/Dialogs/SmartPlaylistEditor.vala
@@ -114,8 +114,8 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
 
         deletable = false;
         destroy_with_parent = true;
-        title = _("Smart Playlist Editor");
         modal = true;
+        title = _("Smart Playlist Editor");
         transient_for = App.main_window;
         window_position = Gtk.WindowPosition.CENTER_ON_PARENT;
         get_content_area ().add (main_grid);

--- a/src/Dialogs/SmartPlaylistEditor.vala
+++ b/src/Dialogs/SmartPlaylistEditor.vala
@@ -49,14 +49,6 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
     }
 
     construct {
-        deletable = false;
-        destroy_with_parent = true;
-        title = _("Smart Playlist Editor");
-        library = library;
-        modal = true;
-        transient_for = App.main_window;
-        window_position = Gtk.WindowPosition.CENTER_ON_PARENT;
-
         name_entry = new Gtk.Entry ();
         name_entry.changed.connect (name_changed);
         name_entry.placeholder_text = _("Playlist Title");
@@ -119,7 +111,14 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
         main_grid.attach (new Granite.HeaderLabel (_("Options")), 0, 5, 3, 1);
         main_grid.attach (limiter_grid, 0, 6, 3, 1);
         main_grid.attach (button_box, 0, 7, 3, 1);
-        ((Gtk.Container) get_content_area ()).add (main_grid);
+
+        deletable = false;
+        destroy_with_parent = true;
+        title = _("Smart Playlist Editor");
+        modal = true;
+        transient_for = App.main_window;
+        window_position = Gtk.WindowPosition.CENTER_ON_PARENT;
+        get_content_area ().add (main_grid);
 
         if (smart_playlist != null) {
             name_entry.text = smart_playlist.name;

--- a/src/Dialogs/SmartPlaylistEditor.vala
+++ b/src/Dialogs/SmartPlaylistEditor.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2012-2017 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2012-2018 elementary LLC. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -28,21 +28,27 @@
  */
 
 public class Noise.SmartPlaylistEditor : Gtk.Dialog {
-    SmartPlaylist sp;
-    private bool is_new = false;
+    public Library library { get; construct; }
+    public SmartPlaylist smart_playlist { get; construct; }
+
     private Gtk.Entry name_entry;
     private Gtk.ComboBoxText match_combobox;
     private Gtk.Button save_button;
-    private Gtk.Grid main_grid;
     private Gtk.Grid queries_grid;
     private Gtk.CheckButton limit_check;
     private Gtk.SpinButton limit_spin;
     private Gtk.Button adding_button;
     private Gee.ArrayList<EditorQuery> queries_list;
     private int row = 0;
-    private Library library;
 
-    public SmartPlaylistEditor (SmartPlaylist? sp = null, Library library) {
+    public SmartPlaylistEditor (SmartPlaylist? smart_playlist = null, Library library) {
+        Object (
+            library: library,
+            smart_playlist: smart_playlist
+        );
+    }
+
+    construct {
         deletable = false;
         destroy_with_parent = true;
         title = _("Smart Playlist Editor");
@@ -51,26 +57,13 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
         transient_for = App.main_window;
         window_position = Gtk.WindowPosition.CENTER_ON_PARENT;
 
-        if (sp == null) {
-            is_new = true;
-            this.sp = new SmartPlaylist (library);
-        } else {
-            this.sp = sp;
-        }
-
         name_entry = new Gtk.Entry ();
         name_entry.changed.connect (name_changed);
         name_entry.placeholder_text = _("Playlist Title");
-        if (is_new == false)
-            name_entry.text = sp.name;
 
         match_combobox = new Gtk.ComboBoxText ();
         match_combobox.insert_text (0, _("any"));
         match_combobox.insert_text (1, _("all"));
-        if (is_new == false)
-            match_combobox.set_active (sp.conditional);
-        else
-            match_combobox.set_active (0);
 
         var match_grid = new Gtk.Grid ();
         match_grid.column_spacing = 12;
@@ -93,14 +86,6 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
         limit_check = new Gtk.CheckButton.with_label (_("Limit to"));
         limit_spin = new Gtk.SpinButton.with_range (0, 500, 10);
 
-        if (is_new == false) {
-            limit_check.set_active (sp.limit);
-            limit_spin.set_value ((double)sp.limit_amount);
-        } else {
-            limit_check.set_active (true);
-            limit_spin.set_value (50);
-        }
-
         limit_spin.sensitive = limit_check.active;
         limit_check.toggled.connect(() => { limit_spin.sensitive = limit_check.active; });
 
@@ -121,7 +106,7 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
         button_box.pack_end (save_button, false, false, 0);
         button_box.spacing = 6;
 
-        main_grid = new Gtk.Grid ();
+        var main_grid = new Gtk.Grid ();
         main_grid.expand = true;
         main_grid.margin_start = main_grid.margin_end = 12;
         main_grid.column_spacing = 12;
@@ -136,12 +121,25 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
         main_grid.attach (button_box, 0, 7, 3, 1);
         ((Gtk.Container) get_content_area ()).add (main_grid);
 
-        load_smart_playlist ();
-    }
+        if (smart_playlist != null) {
+            name_entry.text = smart_playlist.name;
 
-    public void load_smart_playlist () {
+            match_combobox.set_active (smart_playlist.conditional);
+
+            limit_check.set_active (smart_playlist.limit);
+            limit_spin.set_value ((double) smart_playlist.limit_amount);
+        } else {
+            smart_playlist = new SmartPlaylist (library);
+
+            match_combobox.set_active (0);
+
+            limit_check.set_active (true);
+            limit_spin.set_value (50);
+        }
+
         show_all ();
-        var sp_queries = sp.get_queries ();
+
+        var sp_queries = smart_playlist.get_queries ();
         foreach (SmartQuery q in sp_queries) {
             var editor_query = new EditorQuery (q);
             editor_query.removed.connect (() => {queries_list.remove (editor_query);});
@@ -173,7 +171,7 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
         } else {
             foreach (var p in library.get_smart_playlists ()) {
                 var fixed_name = name_entry.text.strip ();
-                if (sp.rowid != p.rowid && fixed_name == p.name) {
+                if (smart_playlist.rowid != p.rowid && fixed_name == p.name) {
                     save_button.set_sensitive (false);
                     return;
                 }
@@ -206,22 +204,23 @@ public class Noise.SmartPlaylistEditor : Gtk.Dialog {
     }
 
     public virtual void save_click () {
-        sp.clear_queries ();
-        sp.clear ();
+        smart_playlist.clear_queries ();
+        smart_playlist.clear ();
         var queries = new Gee.TreeSet<SmartQuery> ();
         foreach (EditorQuery speq in queries_list) {
             var query = speq.get_query ();
             queries.add (query);
         }
 
-        sp.add_queries (queries);
-        sp.name = name_entry.text.strip ();
-        sp.conditional = (SmartPlaylist.ConditionalType) match_combobox.get_active ();
-        sp.limit = limit_check.get_active ();
-        sp.limit_amount = (int)limit_spin.get_value ();
-        if (is_new) {
+        smart_playlist.add_queries (queries);
+        smart_playlist.name = name_entry.text.strip ();
+        smart_playlist.conditional = (SmartPlaylist.ConditionalType) match_combobox.get_active ();
+        smart_playlist.limit = limit_check.get_active ();
+        smart_playlist.limit_amount = (int)limit_spin.get_value ();
+
+        if (smart_playlist == null) {
             App.main_window.newly_created_playlist = true;
-            library.add_smart_playlist (sp);
+            library.add_smart_playlist (smart_playlist);
         }
 
         this.destroy ();


### PR DESCRIPTION
* Rename `sp` to `smart_playlist`
* Use GObject-style construction
* bump copyright
* merge unnecessary public `load_smart_playlist` with construct
* Only check if `smart_playlist` is null once in construct and remove `is_new`
* Remove unnecessary cast to Gtk.Container
* Reduce the scope of `main_grid`
* Use properties in code I touched