### PR TITLE
CD plugin code style cleanups

### DIFF
--- a/plugins/Devices/CDRom/CDRomDeviceManager.vala
+++ b/plugins/Devices/CDRom/CDRomDeviceManager.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2012-2017 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2012-2018 elementary LLC. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -62,16 +62,16 @@ public class Noise.Plugins.CDRomDeviceManager : GLib.Object {
             added.set_mount (mount);
             devices.add (added);
 
-            if (added.start_initialization()) {
-                added.finish_initialization();
-                added.initialized.connect((d) => {
-                    DeviceManager.get_default ().device_initialized ((Noise.Device)d);
+            if (added.start_initialization ()) {
+                added.finish_initialization ();
+                added.initialized.connect ((d) => {
+                    DeviceManager.get_default ().device_initialized ((Noise.Device) d);
                 });
             } else {
-                mount_removed(added.get_mount());
+                mount_removed (added.get_mount ());
             }
         } else {
-            debug ("Found device at %s is not an Audio CD. Not using it", mount.get_default_location().get_parse_name());
+            debug ("Found device at %s is not an Audio CD. Not using it", mount.get_default_location ().get_parse_name ());
             return;
         }
     }
@@ -86,12 +86,12 @@ public class Noise.Plugins.CDRomDeviceManager : GLib.Object {
 
     public virtual void mount_removed (Mount mount) {
         var device_manager = DeviceManager.get_default ();
-        foreach(var dev in devices) {
-            if(dev.get_uri() == mount.get_default_location().get_uri()) {
-                device_manager.device_removed ((Noise.Device)dev);
+        foreach (var dev in devices) {
+            if (dev.get_uri () == mount.get_default_location ().get_uri ()) {
+                device_manager.device_removed ((Noise.Device) dev);
 
                 // Actually remove it
-                devices.remove(dev);
+                devices.remove (dev);
 
                 return;
             }

--- a/plugins/Devices/CDRom/CDRomDeviceManager.vala
+++ b/plugins/Devices/CDRom/CDRomDeviceManager.vala
@@ -42,7 +42,7 @@ public class Noise.Plugins.CDRomDeviceManager : GLib.Object {
 
     public void remove_all () {
         var device_manager = DeviceManager.get_default ();
-        foreach(var dev in devices) {
+        foreach (var dev in devices) {
             device_manager.device_removed ((Noise.Device)dev);
         }
 
@@ -50,25 +50,27 @@ public class Noise.Plugins.CDRomDeviceManager : GLib.Object {
     }
 
     public virtual void mount_added (Mount mount) {
-        foreach(var dev in devices) {
-            if(dev.get_uri() == mount.get_default_location().get_uri()) {
+        foreach (var dev in devices) {
+            if (dev.get_uri () == mount.get_default_location ().get_uri ()) {
                 return;
             }
         }
-        if(mount.get_default_location().get_uri().has_prefix("cdda://") && mount.get_volume() != null) {
-            var added = new CDRomDevice(mount);
-            added.set_mount(mount);
-            devices.add(added);
 
-            if(added.start_initialization()) {
+        if (mount.get_default_location ().get_uri ().has_prefix ("cdda://") && mount.get_volume () != null) {
+            debug ("Adding CD to list");
+            var added = new CDRomDevice (mount);
+            added.set_mount (mount);
+            devices.add (added);
+
+            if (added.start_initialization()) {
                 added.finish_initialization();
-                added.initialized.connect((d) => {DeviceManager.get_default ().device_initialized ((Noise.Device)d);});
-            }
-            else {
+                added.initialized.connect((d) => {
+                    DeviceManager.get_default ().device_initialized ((Noise.Device)d);
+                });
+            } else {
                 mount_removed(added.get_mount());
             }
-        }
-        else {
+        } else {
             debug ("Found device at %s is not an Audio CD. Not using it", mount.get_default_location().get_parse_name());
             return;
         }

--- a/plugins/Devices/CDRom/CDView.vala
+++ b/plugins/Devices/CDRom/CDView.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2012-2017 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2012-2018 elementary LLC. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -28,56 +28,38 @@
 
 public class Noise.Plugins.CDView : Gtk.Grid {
     public CDRomDevice dev { get; construct set; }
-
-    Gtk.EventBox main_event_box;
-    Gtk.Grid main_grid;
-
-    Widgets.AlbumImage album_image;
-
-    Gtk.Label title;
-    Gtk.Label author;
-
-    Noise.StaticPlaylist cd_playlist;
     public CDViewWrapper cd_viewwrapper;
 
-    public CDView (CDRomDevice d) {
-        Object (dev: d);
+    private Gtk.EventBox main_event_box;
+    private Gtk.Grid main_grid;
+    private Gtk.Label title_label;
+    private Gtk.Label author_label;
+    private Noise.StaticPlaylist cd_playlist;
+    private Widgets.AlbumImage album_image;
+
+    public CDView (CDRomDevice device) {
+        Object (dev: device);
     }
 
     construct {
         cd_playlist = new Noise.StaticPlaylist ();
         cd_viewwrapper = new CDViewWrapper (cd_playlist);
 
-        build_ui ();
-
-        dev.initialized.connect (cd_initialised);
-    }
-
-    public void build_ui () {
-        main_event_box = new Gtk.EventBox ();
-        main_grid = new Gtk.Grid ();
-
-        /* Content view styling */
-        main_event_box.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
-
-        if ( cd_playlist.is_empty () == false) {
-        }
-
         album_image = new Widgets.AlbumImage ();
         album_image.image.gicon = new ThemedIcon ("albumart");
         album_image.halign = Gtk.Align.CENTER;
         album_image.valign = Gtk.Align.CENTER;
 
-        title = new Gtk.Label ("");
-        title.set_alignment(0.5f, 1);
-        title.set_justify(Gtk.Justification.CENTER);
-        title.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
+        title_label = new Gtk.Label ("");
+        title_label.justify = Gtk.Justification.CENTER;
+        title_label.valign = Gtk.Align.BOTTOM;
+        title_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
-        author = new Gtk.Label ("");
-        author.set_alignment(0.5f, 1);
-        author.set_justify(Gtk.Justification.CENTER);
-        author.sensitive = false;
-        author.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
+        author_label = new Gtk.Label ("");
+        author_label.justify = Gtk.Justification.CENTER;
+        author_label.sensitive = false;
+        author_label.valign = Gtk.Align.BOTTOM;
+        author_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
         var fake_label_1 = new Gtk.Label ("");
         fake_label_1.set_hexpand (true);
@@ -90,43 +72,50 @@ public class Noise.Plugins.CDView : Gtk.Grid {
         var fake_label_3 = new Gtk.Label ("");
         fake_label_3.set_hexpand (true);
 
-        var import_grid = new Gtk.Grid ();
         var import_button = new Gtk.Button.with_label (_("Import"));
-        import_button.set_alignment(1, 0);
+        import_button.halign = Gtk.Align.END;
+
+        var import_grid = new Gtk.Grid ();
         import_grid.attach (fake_label_3,  0, 0, 1, 1);
         import_grid.attach (import_button, 1, 0, 1, 1);
 
-        main_grid.attach (fake_label_1,   0, 0, 1, 7);
-        main_grid.attach (album_image,    1, 3, 1, 1);
-        main_grid.attach (title,          2, 2, 1, 1);
-        main_grid.attach (author,         3, 2, 1, 1);
+        main_grid = new Gtk.Grid ();
+        main_grid.hexpand = true;
+        main_grid.column_spacing = 12;
+        main_grid.row_spacing = 6;
+        main_grid.margin_top = 12;
+        main_grid.attach (fake_label_1, 0, 0, 1, 7);
+        main_grid.attach (album_image, 1, 3, 1, 1);
+        main_grid.attach (title_label, 2, 2, 1, 1);
+        main_grid.attach (author_label, 3, 2, 1, 1);
         main_grid.attach (cd_viewwrapper, 2, 3, 2, 1);
-        main_grid.attach (import_grid,    3, 4, 1, 1);
-        main_grid.attach (fake_label_2,   4, 0, 1, 7);
+        main_grid.attach (import_grid, 3, 4, 1, 1);
+        main_grid.attach (fake_label_2, 4, 0, 1, 7);
 
+        main_event_box = new Gtk.EventBox ();
+        main_event_box.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
         main_event_box.add (main_grid);
-        this.attach (main_event_box,0,0,1,1);
 
-        /* Create options */
+        add (main_event_box);
 
-        main_grid.set_hexpand (true);
-        main_grid.set_row_spacing (6);
-        main_grid.set_column_spacing (12);
-        main_grid.set_margin_top (12);
-
-        import_button.clicked.connect ( () => {dev.transfer_to_library (cd_playlist.medias);});
+        import_button.clicked.connect (() => {
+            dev.transfer_to_library (cd_playlist.medias);
+        });
 
         show_all ();
+
+        dev.initialized.connect (cd_initialised);
     }
 
     public void cd_initialised () {
         cd_playlist.add_medias (dev.get_medias ());
-        if ( cd_playlist.is_empty () == false) {
+        if (cd_playlist.is_empty () == false) {
             var m = cd_playlist[0];
-            author.set_markup (m.get_display_album_artist (true));
-            title.set_markup (m.get_display_album ());
+            author_label.set_markup (m.get_display_album_artist (true));
+            title_label.set_markup (m.get_display_album ());
             load_cover ();
         }
+
         show_all ();
     }
 
@@ -139,16 +128,18 @@ public class Noise.Plugins.CDView : Gtk.Grid {
 
     public Gtk.Label create_title_label (string title) {
         var label = new Gtk.Label (title);
-        label.set_halign (Gtk.Align.START);
-        label.set_justify(Gtk.Justification.LEFT);
-        label.set_alignment(0, 0);
-        label.set_hexpand (true);
+        label.halign = Gtk.Align.START;
+        label.valign = Gtk.Align.START;
+        label.hexpand = true;
+        label.justify = Gtk.Justification.LEFT;
+
         return label;
     }
 
     public Gtk.Label create_length_label (uint length) {
         var label = new Gtk.Label (TimeUtils.pretty_length_from_ms (length));
-        label.set_justify(Gtk.Justification.RIGHT);
+        label.justify = Gtk.Justification.RIGHT;
+
         return label;
     }
 }

--- a/plugins/Devices/CDRom/CDView.vala
+++ b/plugins/Devices/CDRom/CDView.vala
@@ -52,13 +52,13 @@ public class Noise.Plugins.CDView : Gtk.Grid {
 
         title_label = new Gtk.Label ("");
         title_label.justify = Gtk.Justification.CENTER;
-        title_label.valign = Gtk.Align.BOTTOM;
+        title_label.valign = Gtk.Align.END;
         title_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
         author_label = new Gtk.Label ("");
         author_label.justify = Gtk.Justification.CENTER;
         author_label.sensitive = false;
-        author_label.valign = Gtk.Align.BOTTOM;
+        author_label.valign = Gtk.Align.END;
         author_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
         var fake_label_1 = new Gtk.Label ("");


### PR DESCRIPTION
Some of the CD plugin cleanups from #265 plus a few of my own

* Bump copyright
* Spaces before ()
* Cuddle else
* Properties instead of set methods
* Organize
* `halign` and `valign` instead of `set_alignment`
* `author` and `title` to `author_label` and `title_label`