### PR TITLE
Only install plugins once

### DIFF
--- a/plugins/Devices/AudioPlayers/meson.build
+++ b/plugins/Devices/AudioPlayers/meson.build
@@ -12,5 +12,3 @@ shared_module(
   install: true,
   install_dir: plugindir
 )
-
-install_data('audioplayer-device.plugin', install_dir: plugindir)

--- a/plugins/Devices/CDRom/meson.build
+++ b/plugins/Devices/CDRom/meson.build
@@ -16,5 +16,3 @@ shared_module(
   install: true,
   install_dir: plugindir
 )
-
-install_data('cdrom-device.plugin', install_dir: plugindir)

--- a/plugins/Devices/iPod/meson.build
+++ b/plugins/Devices/iPod/meson.build
@@ -19,5 +19,3 @@ shared_module(
   install: true,
   install_dir: plugindir
 )
-
-install_data('ipod-device.plugin', install_dir: plugindir)

--- a/plugins/LastFM/meson.build
+++ b/plugins/LastFM/meson.build
@@ -22,6 +22,4 @@ shared_module(
   install_dir: plugindir
 )
 
-install_data('lastfm.plugin', install_dir: plugindir)
-
 install_data('noise-lastfm.application', install_dir: join_paths(datadir, 'accounts', 'applications'))


### PR DESCRIPTION
Install is already set to `true` so no need to install the plugin again

![](https://thewarnerblog.files.wordpress.com/2016/08/there-can-be-only-one.jpg?w=800)