### PR TITLE
Explicitly set can scroll to current

### DIFF
--- a/src/Views/ListView/Lists/MusicListView.vala
+++ b/src/Views/ListView/Lists/MusicListView.vala
@@ -57,6 +57,8 @@ public class Noise.ContractMenuItem : Gtk.MenuItem {
 }
 
 public class Noise.MusicListView : GenericList {
+    public bool can_scroll_to_current { get; construct; }
+
     //for media list right click
     Gtk.Menu media_action_menu;
     Gtk.MenuItem media_edit_media;
@@ -69,8 +71,12 @@ public class Noise.MusicListView : GenericList {
     Gtk.MenuItem import_to_library;
     Gtk.MenuItem media_scroll_to_current;
 
-    public MusicListView (ViewWrapper view_wrapper, TreeViewSetup tvs) {
-        Object (parent_wrapper: view_wrapper, tvs: tvs);
+    public MusicListView (ViewWrapper view_wrapper, TreeViewSetup tvs, bool can_scroll_to_current = true) {
+        Object (
+            can_scroll_to_current: can_scroll_to_current,
+            parent_wrapper: view_wrapper,
+            tvs: tvs
+        );
     }
 
     construct {
@@ -108,10 +114,12 @@ public class Noise.MusicListView : GenericList {
 
         media_action_menu = new Gtk.Menu ();
         media_action_menu.attach_to_widget (this, null);
-        if(hint != ViewWrapper.Hint.ALBUM_LIST) {
+
+        if (can_scroll_to_current) {
             media_action_menu.append (media_scroll_to_current);
             media_action_menu.append (new Gtk.SeparatorMenuItem ());
         }
+
         var read_only = hint == ViewWrapper.Hint.READ_ONLY_PLAYLIST;
         if (read_only == false) {
             media_action_menu.append (media_edit_media);

--- a/src/Widgets/AlbumListGrid.vala
+++ b/src/Widgets/AlbumListGrid.vala
@@ -84,7 +84,7 @@ public class Noise.AlbumListGrid : Gtk.Grid {
         artist_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
         var tvs = new TreeViewSetup (ViewWrapper.Hint.ALBUM_LIST);
-        list_view = new MusicListView (view_wrapper, tvs);
+        list_view = new MusicListView (view_wrapper, tvs, false);
         list_view.expand = true;
         list_view.set_search_func (view_search_func);
         list_view.get_style_context ().remove_class (Gtk.STYLE_CLASS_VIEW);


### PR DESCRIPTION
A change from #265 

Explicitly set if a view can be scrolled to the current playing song instead of relying on hints