### PR TITLE
Show a separator above remove menuitem in album sidebar

### DIFF
--- a/src/Views/ListView/Lists/MusicListView.vala
+++ b/src/Views/ListView/Lists/MusicListView.vala
@@ -127,7 +127,6 @@ public class Noise.MusicListView : GenericList {
             media_action_menu.append (media_menu_add_to_playlist);
         }
         if (hint != ViewWrapper.Hint.SMART_PLAYLIST &&
-            hint != ViewWrapper.Hint.ALBUM_LIST &&
             hint != ViewWrapper.Hint.READ_ONLY_PLAYLIST) {
                 media_action_menu.append (new Gtk.SeparatorMenuItem ());
         }


### PR DESCRIPTION
Don't special case the album sidebar here since we want that separator above the "Remove" item here