### PR TITLE
Fix a bug with alert view

### DIFF
--- a/src/Views/ListView/ListView.vala
+++ b/src/Views/ListView/ListView.vala
@@ -357,7 +357,7 @@ public class Noise.ListView : ContentView, Gtk.Box {
                 }
             }
         } else {
-            foreach (var m in table) {
+            foreach (var m in result) {
                 if (obey_column_browser && !column_browser.match_media (m)) {
                     continue;
                 }


### PR DESCRIPTION
It was always showing when playing a new media, because for some reason `table` was empty…