### PR TITLE
Only show alertview when search is non-null

### DIFF
--- a/src/Views/ListView/ListView.vala
+++ b/src/Views/ListView/ListView.vala
@@ -367,7 +367,7 @@ public class Noise.ListView : ContentView, Gtk.Box {
         }
 
         // If nothing will be shown, display the "no media found" message.
-        if (showing.size < 1) {
+        if (showing.size < 1 && search != "") {
             App.main_window.view_stack.show_alert ();
         }
     }


### PR DESCRIPTION
There's another case where results are <1 and that's when the library is empty. Make sure that there are both no results and we're actually searching so that the welcome view shows on first run instead of the no results view