### PR TITLE
Fix inverted privacy mode settings

### DIFF
--- a/core/Settings.vala
+++ b/core/Settings.vala
@@ -54,8 +54,8 @@ namespace Noise.Settings {
 
         public bool privacy_mode_enabled () {
             var privacy_settings = new GLib.Settings ("org.gnome.desktop.privacy");
-            return privacy_settings.get_boolean ("remember-app-usage") ||
-                   privacy_settings.get_boolean ("remember-recent-files");
+            return !(privacy_settings.get_boolean ("remember-app-usage") ||
+                   privacy_settings.get_boolean ("remember-recent-files"));
         }
 
         private Main ()  {


### PR DESCRIPTION
This fixes a bug that causes some state to be lost when privacy mode is inactive, and saves it when privacy mode is active.

Specifically this is used for remembering the last search, last track, etc