### PR TITLE
ViewSelector: Set view actions to disabled when insensitive

### DIFF
--- a/src/LibraryWindow.vala
+++ b/src/LibraryWindow.vala
@@ -156,12 +156,6 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
         }
     }
 
-    private void change_view (Widgets.ViewSelector.Mode mode) {
-        if (view_selector.get_sensitive ()) {
-            view_selector.selected = mode;
-        }
-    }
-
     public override bool key_press_event (Gdk.EventKey event) {
         // when typing in an editable widget, such as Gtk.Entry, don't block the event
         var focus_widget = get_focus ();
@@ -1027,15 +1021,15 @@ public class Noise.LibraryWindow : LibraryWindowInterface, Gtk.Window {
     }
 
     private void action_view_albums () {
-        change_view (Widgets.ViewSelector.Mode.GRID);
+        view_selector.selected = Widgets.ViewSelector.Mode.GRID;
     }
 
     private void action_view_columns () {
-        change_view (Widgets.ViewSelector.Mode.COLUMN);
+        view_selector.selected = Widgets.ViewSelector.Mode.COLUMN;
     }
 
     private void action_view_list () {
-        change_view (Widgets.ViewSelector.Mode.LIST);
+        view_selector.selected = Widgets.ViewSelector.Mode.LIST;
     }
 
     private void editPreferencesClick () {

--- a/src/Views/ViewStack.vala
+++ b/src/Views/ViewStack.vala
@@ -76,7 +76,7 @@ public class Noise.ViewStack : Gtk.Stack {
             ((ViewWrapper) visible_child).set_as_current_view ();
         } else if (visible_child is Gtk.Grid && visible_child_name != "alert") {
             App.main_window.view_selector.selected = Noise.Widgets.ViewSelector.Mode.LIST;
-            App.main_window.view_selector.set_sensitive (false);
+            App.main_window.view_selector.sensitive = false;
             App.main_window.search_entry.set_sensitive (false);
         }
     }

--- a/src/Views/Wrappers/ViewWrapper.vala
+++ b/src/Views/Wrappers/ViewWrapper.vala
@@ -232,9 +232,9 @@ public abstract class Noise.ViewWrapper : Gtk.Grid {
         // View switcher
         // Insensitive if the current view is the welcome/alert screen or if both views
         // are not available (in the queue, device, or playlist sources).
-        App.main_window.view_selector.set_sensitive (has_grid_view && has_list_view
-                                                    && current_view != ViewType.WELCOME
-                                                    && current_view != ViewType.ALERT);
+        App.main_window.view_selector.sensitive = has_grid_view && has_list_view
+                                                  && current_view != ViewType.WELCOME
+                                                  && current_view != ViewType.ALERT;
 
         // Set active mode to column view if it is visible. We have to ensure
         // that it is not null because the column_browser is not guaranteed to

--- a/src/Widgets/ViewSelector.vala
+++ b/src/Widgets/ViewSelector.vala
@@ -63,6 +63,9 @@ public class Noise.Widgets.ViewSelector : Gtk.ToolItem {
             // select fourth invisible mode to appear as de-selected
             mode_button.sensitive = value;
             mode_button.set_active (value ? (int) mode : -1);
+            ((SimpleAction) App.main_window.actions.lookup_action (App.main_window.ACTION_VIEW_ALBUMS)).set_enabled (value);
+            ((SimpleAction) App.main_window.actions.lookup_action (App.main_window.ACTION_VIEW_LIST)).set_enabled (value);
+            ((SimpleAction) App.main_window.actions.lookup_action (App.main_window.ACTION_VIEW_COLUMNS)).set_enabled (value);
         }
     }
 


### PR DESCRIPTION
Instead of checking if the view selector is sensitive before performing actions, set the actions as disabled/enabled when we change the sensitivity of the selector.

Also use the `sensitive` property instead of `set_sensitive` to fix the selector not being unselected while insensitive