### PR TITLE
AlbumsView: remove button press mask

### DIFF
--- a/src/Views/AlbumsView.vala
+++ b/src/Views/AlbumsView.vala
@@ -71,16 +71,6 @@ public class Noise.AlbumsView : Gtk.Paned, ViewInterface {
             queue_resize ();
         });
 
-        var focus_blacklist = new Gee.LinkedList<Gtk.Widget> ();
-        focus_blacklist.add (App.main_window.view_selector);
-        focus_blacklist.add (App.main_window.search_entry);
-        focus_blacklist.add (App.main_window.source_list_view);
-        focus_blacklist.add (App.main_window.statusbar);
-
-        foreach (var w in focus_blacklist) {
-            w.add_events (Gdk.EventMask.BUTTON_PRESS_MASK);
-        }
-
         parent_view_wrapper.library.search_finished.connect (() => {
             icon_view.research_needed = true;
         });


### PR DESCRIPTION
Fixes #381 

It looks like this was used to close the album dialog back when. Now that we have it as a sidebar we don't need/want to close it every time we focus some other widget