### PR TITLE
Overwrite system iconview css

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -16,6 +16,15 @@
 * Boston, MA 02110-1301 USA
 */
 
+iconview {
+    border-radius: 0;
+    color: @text_color;
+}
+
+iconview.cell {
+    background-color: transparent;
+}
+
 .album {
     background-image:
         linear-gradient(


### PR DESCRIPTION
Hotfix for a style regression.

Ideally we make these styles jive with all our apps, but for now this fixes the broken looking style