### PR TITLE
EqualizerPopover: use GLib.Settings

### DIFF
--- a/core/Settings.vala
+++ b/core/Settings.vala
@@ -64,6 +64,7 @@ namespace Noise.Settings {
     }
 
     public class Equalizer : Granite.Services.Settings {
+
         public bool equalizer_enabled { get; set; }
         public bool auto_switch_preset { get; set; }
         public string selected_preset { get; set; }

--- a/core/Settings.vala
+++ b/core/Settings.vala
@@ -64,7 +64,6 @@ namespace Noise.Settings {
     }
 
     public class Equalizer : Granite.Services.Settings {
-
         public bool equalizer_enabled { get; set; }
         public bool auto_switch_preset { get; set; }
         public string selected_preset { get; set; }

--- a/src/Widgets/EqualizerPopover.vala
+++ b/src/Widgets/EqualizerPopover.vala
@@ -189,8 +189,8 @@ public class Noise.EqualizerPopover : Gtk.Popover {
         add (layout);
 
         equalizer_settings.bind ("equalizer-enabled", eq_switch, "active", GLib.SettingsBindFlags.DEFAULT);
-        equalizer_settings.bind ("equalizer-enabled", preset_combo, "sensitive", GLib.SettingsBindFlags.DEFAULT);
-        equalizer_settings.bind ("equalizer-enabled", scale_container, "sensitive", GLib.SettingsBindFlags.DEFAULT);
+        equalizer_settings.bind ("equalizer-enabled", preset_combo, "sensitive", GLib.SettingsBindFlags.GET);
+        equalizer_settings.bind ("equalizer-enabled", scale_container, "sensitive", GLib.SettingsBindFlags.GET);
 
         eq_switch.notify["active"].connect (on_eq_switch_toggled);
         preset_combo.automatic_preset_chosen.connect (on_automatic_chosen);


### PR DESCRIPTION
Use GLib.Settings in EqualizerPopover where convenient.

Several of these settings are still touched in PlayBackManager so they can't be removed until that gets resolved. This is the same reason why I didn't touch the `get_presets ()` method.

Took the opportunity to change a few things to a settings bind