### PR TITLE
FileNotFoundDialog: Rewrite as a Granite.MessageDialog

### DIFF
--- a/src/Dialogs/FileNotFoundDialog.vala
+++ b/src/Dialogs/FileNotFoundDialog.vala
@@ -28,17 +28,18 @@
  */
 
 public class Noise.FileNotFoundDialog : Granite.MessageDialog {
-    private Gee.LinkedList<Media> media_list = new Gee.LinkedList<Media> ();
+    private Gee.LinkedList<Media> media_list;
 
     public FileNotFoundDialog (Gee.Collection<Media> _media_list) {
         Object (
+            destroy_with_parent: true,
             image_icon: new ThemedIcon ("dialog-warning"),
             primary_text: _("File not found"),
             transient_for: App.main_window
         );
 
+        media_list = new Gee.LinkedList<Media> ();
         media_list.add_all (_media_list);
-        this.destroy_with_parent = true;
 
         if (media_list.size == 1) {
             var s = media_list.get (0);


### PR DESCRIPTION
Save a bunch of code by rewriting as a Granite.MessageDialog. Also fixes an issue with trying to set a null widget's sensitivity.

## BEFORE
![screenshot from 2018-09-10 12 05 11 2x](https://user-images.githubusercontent.com/7277719/45316190-9d112800-b4f3-11e8-9e90-e1793c5b9373.png)

## AFTER
![screenshot from 2018-09-10 12 12 38 2x](https://user-images.githubusercontent.com/7277719/45316195-a0a4af00-b4f3-11e8-8454-b410052ed243.png)
