### PR TITLE
Handle error when a LocalMedia constructor fail

### DIFF
--- a/src/LocalBackend/LocalMedia.vala
+++ b/src/LocalBackend/LocalMedia.vala
@@ -323,7 +323,7 @@ public class Noise.LocalMedia : Noise.Media {
     }
 
     // To use this method, the rowid should exist in the database.
-    public LocalMedia.from_media (Gda.Connection connection, Media m) {
+    public LocalMedia.from_media (Gda.Connection connection, Media m) throws Error {
         try {
             var builder = new Gda.SqlBuilder (Gda.SqlStatementType.INSERT);
             builder.set_table (Database.Media.TABLE_NAME);
@@ -389,7 +389,7 @@ public class Noise.LocalMedia : Noise.Media {
             values.append (m.show);
             connection.update_row_in_table_v (Database.Media.TABLE_NAME, "rowid", last_insert_row.get_holder_value (Database.Media.ROWID), col_names, values);
         } catch (Error e) {
-            warning ("Could not save media: %s", e.message);
+            throw e;
         }
 
         var query = Database.query_field (rowid, connection, Database.Media.TABLE_NAME, "uri");


### PR DESCRIPTION
Fixes error when constructor fails propagating null object all over, therefore generating a lot of critical warnings and that might be a cause of some Noise's crashes

Output **before** fix
Total output lines(w/o empty lines): **9980 lines**
First 30 lines collapsing repeated errors
```
(io.elementary.music:24991): GLib-GObject-CRITICAL **: 21:24:22.334: g_value_get_string: assertion 'G_VALUE_HOLDS_STRING (value)' failed
(io.elementary.music:24991): GLib-GObject-CRITICAL **: 21:24:22.401: g_value_get_string: assertion 'G_VALUE_HOLDS_STRING (value)' failed
(io.elementary.music:24991): GLib-GObject-CRITICAL **: 21:24:22.619: Read-only property 'read-only-view' on class 'GeeReadOnlyBidirSortedSet' has type 'GeeSortedSet' which is not equal to or more restrictive than the type 'GeeBidirSortedSet' of the property on the interface 'GeeBidirSortedSet'
(io.elementary.music:24991): Gtk-WARNING **: 21:24:22.797: Can't set a parent on widget which has a parent
** (io.elementary.music:24991): WARNING **: 21:24:23.092: LocalMedia.vala:392: Could not save media: UNIQUE constraint failed: media.uri
** (io.elementary.music:24991): CRITICAL **: 21:24:23.092: noise_media_get_rowid: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.093: DataBase.vala:111: Could not query field uri: A linha 0 não foi localizada (modelo de dados vazio)
** (io.elementary.music:24991): CRITICAL **: 21:24:23.093: noise_media_get_rowid: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.093: noise_media_get_album_hashkey: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.093: noise_media_get_album_info: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.093: noise_album_construct_from_media: assertion 'media != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.093: noise_album_add_media: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.093: noise_album_get_hashkey: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.093: noise_album_get_cover_icon: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.093: noise_cover_import_construct: assertion 'album != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.093: noise_media_get_rating: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.095: noise_search_match_fields_to_media: assertion 'media != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.098: noise_music_list_view_view_compare_func: assertion 'media_a != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.103: noise_media_get_rating: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.105: noise_search_match_fields_to_media: assertion 'media != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.108: noise_media_get_album_info: assertion 'self != NULL' failed
(io.elementary.music:24991): GLib-GObject-WARNING **: 21:24:23.108: invalid (NULL) pointer instance
(io.elementary.music:24991): GLib-GObject-CRITICAL **: 21:24:23.108: g_signal_connect_object: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.109: noise_albums_view_compare_func: assertion 'o_a != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.110: noise_media_get_album_info: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.110: noise_media_get_rating: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.114: noise_search_match_fields_to_media: assertion 'media != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.114: noise_media_get_album_info: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.171: noise_album_get_cached_cover_pixbuf: assertion 'self != NULL' failed
** (io.elementary.music:24991): CRITICAL **: 21:24:23.171: noise_album_get_display_artist: assertion 'self != NULL' failed
```

Output **after** fix
Total output lines(w/o empty lines): **48 lines**
First 7 lines, the others 41 lines were the same last warning
```
(io.elementary.music:25723): GLib-GObject-CRITICAL **: 21:35:22.278: g_value_get_string: assertion 'G_VALUE_HOLDS_STRING (value)' failed
(io.elementary.music:25723): GLib-GObject-CRITICAL **: 21:35:22.584: g_value_get_string: assertion 'G_VALUE_HOLDS_STRING (value)' failed
(io.elementary.music:25723): GLib-GObject-CRITICAL **: 21:35:22.839: Read-only property 'read-only-view' on class 'GeeReadOnlyBidirSortedSet' has type 'GeeSortedSet' which is not equal to or more restrictive than the type 'GeeBidirSortedSet' of the property on the interface 'GeeBidirSortedSet'
(io.elementary.music:25723): Gtk-WARNING **: 21:35:23.025: Can't set a parent on widget which has a parent
(io.elementary.music:25723): Gtk-WARNING **: 21:35:23.025: Can't set a parent on widget which has a parent
(io.elementary.music:25723): Gtk-WARNING **: 21:35:23.025: Can't set a parent on widget which has a parent
** (io.elementary.music:25723): WARNING **: 21:35:23.323: LocalLibrary.vala:936: UNIQUE constraint failed: media.uri
...
```