### PR TITLE
Fix warning: Can't set a parent on widget which has a parent

### DIFF
--- a/src/Widgets/MediaMenu.vala
+++ b/src/Widgets/MediaMenu.vala
@@ -117,6 +117,7 @@ public class Noise.MediaMenu : Gtk.Menu {
                 append (new Gtk.SeparatorMenuItem ());
                 append (remove_media);
                 remove_media.label = _("Remove from Queue");
+                break;
             case ViewWrapper.Hint.READ_ONLY_PLAYLIST:
             default:
                 append (scroll_to_current);


### PR DESCRIPTION
Apparently, someone forgot a break statement on end of the switch