### PR TITLE
Add orange accent color

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -16,6 +16,8 @@
 * Boston, MA 02110-1301 USA
 */
 
+@define-color colorAccent @ORANGE_500;
+
 iconview {
     border-radius: 0;
     color: @text_color;


### PR DESCRIPTION
Switches the accent color to orange, which gives it a nice subtle brand effect imho. Affects overshoot scroll feedback, selected tracks, loading bars, switches, etc.

![screenshot from 2018-10-19 16 18 01](https://user-images.githubusercontent.com/611168/47246397-c195d500-d3ba-11e8-9ef5-63baeb91fdac.png)

![screenshot from 2018-10-19 16 18 08](https://user-images.githubusercontent.com/611168/47246396-c195d500-d3ba-11e8-9fdf-17d5370af210.png)