### PR TITLE
Spelling: Occurred, Could not load audio CD

### DIFF
--- a/plugins/Devices/CDRom/CDRomDevice.vala
+++ b/plugins/Devices/CDRom/CDRomDevice.vala
@@ -330,7 +330,7 @@ public class Noise.Plugins.CDRomDevice : GLib.Object, Noise.Device {
             }
         }
         else {
-            warning("Just-imported song from CD could not be found at %s\n", lib_copy.uri);
+            warning("Just imported song from CD could not be found at %s\n", lib_copy.uri);
             //s.file_size = 5; // best guess
         }
 
@@ -351,7 +351,7 @@ public class Noise.Plugins.CDRomDevice : GLib.Object, Noise.Device {
             _is_transferring = false;
 
             int n_songs = current_list_index + 1;
-            infobar_message (ngettext (_("Importation of a song from Audio CD finished."), _("Importation of %i songs from Audio CD finished.").printf(n_songs), n_songs), Gtk.MessageType.INFO);
+            infobar_message (ngettext (_("Song imported from Audio CD."), _("%i songs imported from Audio CD.").printf(n_songs), n_songs), Gtk.MessageType.INFO);
         }
     }
 
@@ -380,7 +380,7 @@ public class Noise.Plugins.CDRomDevice : GLib.Object, Noise.Device {
             cancel_transfer();
             media_being_ripped = null;
             _is_transferring = false;
-            infobar_message (_("An error occured during the Import of this CD"), Gtk.MessageType.ERROR);
+            infobar_message (_("Could not import this CD"), Gtk.MessageType.ERROR);
         }
     }
 }

--- a/plugins/Devices/CDRom/CDViewWrapper.vala
+++ b/plugins/Devices/CDRom/CDViewWrapper.vala
@@ -34,8 +34,8 @@ public class Noise.Plugins.CDViewWrapper : ViewWrapper {
     public CDViewWrapper (Noise.StaticPlaylist p) {
         base (ViewWrapper.Hint.READ_ONLY_PLAYLIST, libraries_manager.local_library);
         tvs = new TreeViewSetup (ViewWrapper.Hint.PLAYLIST);
-        message_head = _("An Error Occured");
-        message_body = _("There was an error while loading this Audio CD.");
+        message_head = _("An Error Occurred");
+        message_body = _("Could not load this Audio CD.");
 
         build_async.begin (p);
         p.media_added.connect (on_playlist_media_added);

--- a/src/Dialogs/MediaEditor.vala
+++ b/src/Dialogs/MediaEditor.vala
@@ -115,7 +115,7 @@ public class Noise.MediaEditor : Gtk.Dialog {
         grid.attach (year_spinbutton, 1, 7, 1, 1);
         grid.attach (new Granite.HeaderLabel (_("Track:")), 1, 8, 1, 1);
         grid.attach (track_spinbutton, 1, 9, 1, 1);
-        grid.attach (new Granite.HeaderLabel (_("Disk:")), 1, 10, 1, 1);
+        grid.attach (new Granite.HeaderLabel (_("Disc:")), 1, 10, 1, 1);
         grid.attach (disk_spinbutton, 1, 11, 1, 1);
         grid.attach (new Granite.HeaderLabel (_("Rating:")), 1, 12, 1, 1);
         grid.attach (rating_widget, 1, 13, 1, 1);


### PR DESCRIPTION
Disc:
"In most varieties of English, disk is the correct spelling for magnetic media (hence hard disk or disk drive), whereas the variant disc is usually preferred with optical media (hence compact disc or disc film)."

https://en.wiktionary.org/wiki/disk

Other errors spotted by @Sporiff :)