### PR TITLE
Make albums order fixed every run.

### DIFF
--- a/src/Views/AlbumsView.vala
+++ b/src/Views/AlbumsView.vala
@@ -306,7 +306,15 @@ public class Noise.AlbumsView : Gtk.Paned, ViewInterface {
 
     protected void search_func (Gee.HashMap<int, Object> showing) {
         var result = parent_view_wrapper.library.get_search_result ();
-        var albums = new Gee.TreeSet<Album> ();
+        var albums = new Gee.TreeSet<Album> ((a,b) => {
+            if (a == b) {
+                return 0;
+            } else if (a.name < b.name) { 
+                return -1;
+            } else {
+                return 1;
+            }
+        });
         foreach (var m in result) {
             albums.add (m.album_info);
         }

--- a/src/Views/AlbumsView.vala
+++ b/src/Views/AlbumsView.vala
@@ -307,13 +307,7 @@ public class Noise.AlbumsView : Gtk.Paned, ViewInterface {
     protected void search_func (Gee.HashMap<int, Object> showing) {
         var result = parent_view_wrapper.library.get_search_result ();
         var albums = new Gee.TreeSet<Album> ((a,b) => {
-            if (a == b) {
-                return 0;
-            } else if (a.name < b.name) { 
-                return -1;
-            } else {
-                return 1;
-            }
+            return String.compare (a.get_display_name (), b.get_display_name ());
         });
         foreach (var m in result) {
             albums.add (m.album_info);

--- a/src/Views/AlbumsView.vala
+++ b/src/Views/AlbumsView.vala
@@ -307,7 +307,17 @@ public class Noise.AlbumsView : Gtk.Paned, ViewInterface {
     protected void search_func (Gee.HashMap<int, Object> showing) {
         var result = parent_view_wrapper.library.get_search_result ();
         var albums = new Gee.TreeSet<Album> ((a,b) => {
-            return String.compare (a.get_display_name (), b.get_display_name ());
+            int order = String.compare (a.get_display_name (), b.get_display_name ());
+            if (order != 0) {
+                return order;
+            }
+
+            order = String.compare (a.get_display_artist (), b.get_display_artist ());
+            if (order != 0) {
+                return order;
+            }
+
+            return (int) a.year - (int) b.year;
         });
         foreach (var m in result) {
             albums.add (m.album_info);


### PR DESCRIPTION
Fixes #231 
Albums appear in a different order every run, due to not suitable compare function in the TreeSet.