### PR TITLE
Fix: Blurred album images at high resolutions

### DIFF
--- a/src/Widgets/FastView/TileView/TileRenderer.vala
+++ b/src/Widgets/FastView/TileView/TileRenderer.vala
@@ -123,10 +123,10 @@ internal class Noise.Widgets.TileRenderer : Gtk.CellRenderer {
             int scale_factor = ctx.get_scale ();
 
             /* Draws the symbol with the specified scaling factor on a surface. */
-            Cairo.Surface surf = Gdk.cairo_surface_create_from_pixbuf(pixbuf, scale_factor, null);
+            var surface = Gdk.cairo_surface_create_from_pixbuf (pixbuf, scale_factor, null);
 
             /* Renders the symbol with the specified x- and y-coordinates on the surface. */
-            ctx.render_icon_surface(cr, surf, x, y);
+            ctx.render_icon_surface (cr, surface, x, y);
         }
 
         cr.fill_preserve ();

--- a/src/Widgets/FastView/TileView/TileRenderer.vala
+++ b/src/Widgets/FastView/TileView/TileRenderer.vala
@@ -119,7 +119,14 @@ internal class Noise.Widgets.TileRenderer : Gtk.CellRenderer {
         ctx.render_background (cr, x, y, 128, 128);
 
         if (pixbuf != null) {
-            ctx.render_icon (cr, pixbuf, x, y);
+            /* Scaling factor for the album cover, required for monitors with high resolutions.  */
+            int scale_factor = ctx.get_scale ();
+
+            /* Draws the symbol with the specified scaling factor on a surface. */
+            Cairo.Surface surf = Gdk.cairo_surface_create_from_pixbuf(pixbuf, scale_factor, null);
+
+            /* Renders the symbol with the specified x- and y-coordinates on the surface. */
+            ctx.render_icon_surface(cr, surf, x, y);
         }
 
         cr.fill_preserve ();
@@ -151,8 +158,10 @@ internal class Noise.Widgets.TileRenderer : Gtk.CellRenderer {
     private void update_layout_properties (Gtk.Widget widget) {
         var ctx = widget.get_style_context ();
         var state = ctx.get_state ();
+        var scale = ctx.get_scale ();
 
-        pixbuf = album.get_cached_cover_pixbuf (1);
+        /* Gets the buffer for the album cover with the specified scaling factor. */
+        pixbuf = album.get_cached_cover_pixbuf (scale);
 
         border.left = 12;
         border.right = 12;

--- a/src/Widgets/FastView/TileView/TileRenderer.vala
+++ b/src/Widgets/FastView/TileView/TileRenderer.vala
@@ -119,13 +119,10 @@ internal class Noise.Widgets.TileRenderer : Gtk.CellRenderer {
         ctx.render_background (cr, x, y, 128, 128);
 
         if (pixbuf != null) {
-            /* Scaling factor for the album cover, required for monitors with high resolutions.  */
             int scale_factor = ctx.get_scale ();
 
-            /* Draws the symbol with the specified scaling factor on a surface. */
             var surface = Gdk.cairo_surface_create_from_pixbuf (pixbuf, scale_factor, null);
 
-            /* Renders the symbol with the specified x- and y-coordinates on the surface. */
             ctx.render_icon_surface (cr, surface, x, y);
         }
 
@@ -160,7 +157,6 @@ internal class Noise.Widgets.TileRenderer : Gtk.CellRenderer {
         var state = ctx.get_state ();
         var scale = ctx.get_scale ();
 
-        /* Gets the buffer for the album cover with the specified scaling factor. */
         pixbuf = album.get_cached_cover_pixbuf (scale);
 
         border.left = 12;


### PR DESCRIPTION
Fixes #395 

Adds support for loading album art on **HiDPI** monitors with the correct resolution.

Bei Monitoren mit hohen HiDPI Werten werden die Albumcover mit der falschen Auflösung geladen. Dieser Fix berücksichtigt den Skalierungsfaktor.

### BEFORE
![github elementary music_old](https://user-images.githubusercontent.com/29308797/52673317-a8dc9c80-2f20-11e9-994a-fe18383725d7.png)
### AFTER
![github elementary music_new](https://user-images.githubusercontent.com/29308797/52673316-a8dc9c80-2f20-11e9-81b4-5e79f5feb0ac.png)

