### PR TITLE
Application: Remove duplicate l10n support

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -105,13 +105,6 @@ public static int main (string[] args) {
         error ("Could not init GStreamer: %s", err.message);
     }
 
-    // Init internationalization support before anything else
-    string package_name = Build.GETTEXT_PACKAGE;
-    string langpack_dir = Path.build_filename (Build.DATADIR, "locale");
-    Intl.setlocale (LocaleCategory.ALL, "");
-    Intl.bindtextdomain (package_name, langpack_dir);
-    Intl.bind_textdomain_codeset (package_name, "UTF-8");
-    Intl.textdomain (package_name);
     GLib.Environ.set_variable ({"PULSE_PROP_media.role"}, "audio", "true");
 
     var app = new Noise.App ();


### PR DESCRIPTION
Pretty sure we don't need this since we're a Gtk.Application subclass