### PR TITLE
AudioPlayerDeviceManager: Use actual OR operator

### DIFF
--- a/plugins/Devices/AudioPlayers/AudioPlayerDeviceManager.vala
+++ b/plugins/Devices/AudioPlayers/AudioPlayerDeviceManager.vala
@@ -55,7 +55,7 @@ public class Music.Plugins.AudioPlayerDeviceManager : GLib.Object {
             }
         }
         if (
-            File.new_for_uri (mount.get_default_location ().get_uri () + "/Android").query_exists () |
+            File.new_for_uri (mount.get_default_location ().get_uri () + "/Android").query_exists () ||
             File.new_for_uri (mount.get_default_location ().get_uri () + "/.is_audio_player").query_exists ()
         ) {
             var added = new AudioPlayerDevice (


### PR DESCRIPTION
I'm not 100% sure of the ramifications of this, but I presume Android and/or USB audio players were not being detected correctly here.