### PR TITLE
Properly disable equalizer levels

### DIFF
--- a/data/io.elementary.music.appdata.xml.in
+++ b/data/io.elementary.music.appdata.xml.in
@@ -14,6 +14,7 @@
     <release version="5.0.5" date="2019-11-14" urgency="medium">
       <description>
         <p>Fix removing items from the queue</p>
+        <p>Fix equalizer sliders not properly disabled sometimes</p>
         <p>Updated translations</p>
         <p>Performance improvements</p>
       </description>

--- a/src/Widgets/EqualizerPopover.vala
+++ b/src/Widgets/EqualizerPopover.vala
@@ -261,7 +261,7 @@ public class Music.EqualizerPopover : Gtk.Popover {
             return;
         }
 
-        scale_container.sensitive = true;
+        scale_container.sensitive = equalizer_settings.get_boolean ("equalizer-enabled");
         target_levels.clear ();
 
         foreach (int i in p.gains)


### PR DESCRIPTION
If you had equalizer turned off and selected anything except "Automatic", level sliders were still enabled.