### PR TITLE
Music: Give Top Display more contrast.

### DIFF
--- a/src/Widgets/TopDisplay.vala
+++ b/src/Widgets/TopDisplay.vala
@@ -75,7 +75,7 @@ public class Music.TopDisplay : Gtk.Stack {
         add_named (action_grid, "action");
         add_named (time_grid, "time");
         add_named (empty_grid, "empty");
-        get_style_context ().add_class (Gtk.STYLE_CLASS_TITLE);
+        get_style_context ().add_class (Gtk.STYLE_CLASS_ENTRY);
         show_all ();
 
         visible_child = empty_grid;


### PR DESCRIPTION

![Screenshot from 2020-10-09 13 34 16@2x](https://user-images.githubusercontent.com/2386630/95616063-372b5d80-0a37-11eb-88a4-3379bb4e9487.png)
![Screenshot from 2020-10-09 13-53-02@2x](https://user-images.githubusercontent.com/2386630/95616065-37c3f400-0a37-11eb-8b58-603152cec016.png)

By switching from
Gtk.STYLE_CLASS_TITLEBAR to Gtk.STYLE_CLASS_ENTRY  the application tends look nicer, But with third party themes the look bake.