### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,15 @@ add_global_arguments([
     language:'c'
 )
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 subdir('core')
 subdir('data')
 
@@ -95,6 +104,7 @@ app_files = files(
 app = executable (
     meson.project_name(),
     app_files,
+    config_file,
     icon_res,
     dependencies: app_deps,
     install: true
@@ -104,6 +114,7 @@ app = executable (
 app_shared_lib = static_library(
     'music-lib',
     app_files,
+    config_file,
     dependencies: app_deps
 )
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -47,6 +47,11 @@ public class Music.App : Gtk.Application {
         // App info
         application_id = "io.elementary.music";
 
+        GLib.Intl.setlocale (LocaleCategory.ALL, "");
+        GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        GLib.Intl.textdomain (GETTEXT_PACKAGE);
+
         weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
         default_theme.add_resource_path ("/io/elementary/music");
 

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are packaging this in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch, I hope this patch can also help in Flatpak packaging if the community decides to do this in the future.

Some similar PRs:

- https://github.com/elementary/tasks/pull/258
- https://github.com/elementary/calculator/pull/186
- https://github.com/elementary/camera/pull/164

See also: https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580

Thanks in advance for reviewing this :-)