### PR TITLE
flatpak: update SDK and add zeitgeist

### DIFF
--- a/io.elementary.music.yml
+++ b/io.elementary.music.yml
@@ -1,6 +1,6 @@
 app-id: io.elementary.music
 runtime: io.elementary.Platform
-runtime-version: '0.1.0'
+runtime-version: 'daily'
 sdk: io.elementary.Sdk
 command: io.elementary.music
 finish-args:
@@ -72,6 +72,42 @@ modules:
         - type: git
           url: https://github.com/taglib/taglib.git
           tag: v1.12
+
+  - name: python3-isodate
+    buildsystem: simple
+    build-commands:
+      - 'pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} isodate-0.6.0.tar.gz'
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/b1/80/fb8c13a4cd38eb5021dc3741a9e588e4d1de88d895c1910c6fc8a08b7a70/isodate-0.6.0.tar.gz
+        sha256: 2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8
+
+  - name: python3-pyparsing
+    buildsystem: simple
+    build-commands:
+      - 'pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} pyparsing-2.4.7.tar.gz'
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/c1/47/dfc9c342c9842bbe0036c7f763d2d6686bcf5eb1808ba3e170afdb282210/pyparsing-2.4.7.tar.gz
+        sha256: c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1
+
+  - name: python3-rdflib
+    buildsystem: simple
+    build-commands:
+      - 'pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} rdflib-6.0.1.tar.gz'
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/9a/43/0a5bcaeb7cac3db3cf02ce3a2030cdbdd3d9000402cc859753951ca2596f/rdflib-6.0.1.tar.gz
+        sha256: f071caff0b68634e4a7bd1d66ea3416ac98f1cc3b915938147ea899c32608728
+
+  - name: zeitghest
+    buildsystem: autotools
+    config-opts:
+      - '--enable-telepathy=false'
+    sources:
+        - type: git
+          url: https://gitlab.freedesktop.org/zeitgeist/zeitgeist.git
+          tag: v1.0.3
 
   - name: music
     buildsystem: meson

--- a/io.elementary.music.yml
+++ b/io.elementary.music.yml
@@ -1,6 +1,6 @@
 app-id: io.elementary.music
 runtime: io.elementary.Platform
-runtime-version: 'daily'
+runtime-version: '6'
 sdk: io.elementary.Sdk
 command: io.elementary.music
 finish-args:
@@ -100,7 +100,7 @@ modules:
         url: https://files.pythonhosted.org/packages/9a/43/0a5bcaeb7cac3db3cf02ce3a2030cdbdd3d9000402cc859753951ca2596f/rdflib-6.0.1.tar.gz
         sha256: f071caff0b68634e4a7bd1d66ea3416ac98f1cc3b915938147ea899c32608728
 
-  - name: zeitghest
+  - name: zeitgeist
     buildsystem: autotools
     config-opts:
       - '--enable-telepathy=false'


### PR DESCRIPTION
* The 0.1.0 SDK doesn't exist
* zeitgeist is needed to build