### PR TITLE
Use FileChooserNative to choose music folder

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -52,6 +52,8 @@ public class Music.App : Gtk.Application {
         GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
         GLib.Intl.textdomain (GETTEXT_PACKAGE);
 
+        Environment.set_variable ("GTK_USE_PORTAL", "1", true);
+
         weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
         default_theme.add_resource_path ("/io/elementary/music");
 


### PR DESCRIPTION
This changes the one remaining place that does not use the filechooser portal to use it.  Also changes the environment so that the portal is in fact used even if not Flatpak'd, in line with other elementary core apps such as Code.

There seems to be no way to get FileChooserButton to use the FileChooserNative interface and moreover this widget does not seem to appear in Gtk4 so it is replaced with an ordinary button.

Needs input from UX team as to what the desired appearance is.

![MusicFolderLocationButton](https://user-images.githubusercontent.com/10513844/143268280-0d3b6055-627e-4062-b0de-50892d92624f.png)
