### PR TITLE
Fix data/meson.build

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -27,7 +27,6 @@ install_data(
 
 i18n = import('i18n')
 desktop_file = i18n.merge_file(
-    'desktop',
     input: meson.project_name() + '.desktop.in',
     output: meson.project_name() + '.desktop',
     install: true,
@@ -37,7 +36,6 @@ desktop_file = i18n.merge_file(
 )
 
 appdata_file = i18n.merge_file(
-    'appdata',
     input: meson.project_name() + '.appdata.xml.in',
     output: meson.project_name() + '.appdata.xml',
     install: true,


### PR DESCRIPTION
`i18n.merge_file` has been ignoring positional arguments for a time and explicitly rejects with error since meson 0.60.0.