### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,15 @@ i18n = import('i18n')
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()), language:'c')
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 granite_dep = dependency('granite-7')
 gstreamer_dep = dependency('gstreamer-1.0')
 gstreamer_pbutils_dep = dependency('gstreamer-pbutils-1.0')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -26,6 +26,13 @@ public class Music.Application : Gtk.Application {
         );
     }
 
+    construct {
+        GLib.Intl.setlocale (LocaleCategory.ALL, "");
+        GLib.Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, Constants.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
+        GLib.Intl.textdomain (Constants.GETTEXT_PACKAGE);
+    }
+
     protected override void activate () {
         if (active_window == null) {
             add_action_entries (ACTION_ENTRIES, this);

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,4 @@
+namespace Constants {
+    public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+    public const string LOCALEDIR = @LOCALEDIR@;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ executable(
     meson.project_name(),
     gresource,
     sources,
+    config_file,
     dependencies: dependencies,
     install: true
 )


### PR DESCRIPTION
#648 but targets the `main` branch this time. Tested on NixOS with locale `zh_CN.UTF-8`.

Thanks in advance for reviewing this :-)