### PR TITLE
Use file basename instead of uri for the default audio object title.

### DIFF
--- a/src/PlaybackManager.vala
+++ b/src/PlaybackManager.vala
@@ -81,7 +81,14 @@ public class Music.PlaybackManager : Object {
         foreach (unowned var file in files) {
             if (file.query_exists ()) {
                 var audio_object = new AudioObject (file.get_uri ());
-                audio_object.title = audio_object.uri;
+
+                string? basename = file.get_basename ();
+
+                if (basename != null) {
+                    audio_object.title = basename;
+                } else {
+                    audio_object.title = audio_object.uri;
+                }
 
                 discoverer.discover_uri_async (audio_object.uri);
 


### PR DESCRIPTION
It appears that if the audio file doesn't have a title tag then Music uses the ugly file URI by default. This PR uses the prettier file basename if available otherwise falls back to the URI anyway.

See the track title on both panes - playlist on the left and above the progress bar on the right.

Before:

![image](https://user-images.githubusercontent.com/612302/169670274-e8eb9e1e-4ea8-4422-b825-aec628b4e6c7.png)

After:

![image](https://user-images.githubusercontent.com/612302/169670298-772f36fc-59d2-4e04-bd1e-5b9e341d2f40.png)
