### PR TITLE
Application: hard code gtk styles

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -74,6 +74,9 @@ public class Music.Application : Gtk.Application {
         var granite_settings = Granite.Settings.get_default ();
         var gtk_settings = Gtk.Settings.get_default ();
 
+        gtk_settings.gtk_icon_theme_name = "elementary";
+        gtk_settings.gtk_theme_name = "io.elementary.stylesheet.orange";
+
         gtk_settings.gtk_application_prefer_dark_theme = (
             granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK
         );

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -11,11 +11,6 @@ public class Music.MainWindow : Gtk.ApplicationWindow {
     construct {
         var playback_manager = PlaybackManager.get_default ();
 
-        var css_provider = new Gtk.CssProvider ();
-        css_provider.load_from_data ("@define-color accent_color @ORANGE_500;".data);
-
-        Gtk.StyleContext.add_provider_for_display (Gdk.Display.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
         var start_window_controls = new Gtk.WindowControls (Gtk.PackType.START) {
             hexpand = true
         };


### PR DESCRIPTION
Fixes #718 #721 

We've received a few duplicate issue reports about styles being broken on non-elementary OS systems. This hard codes styles to use the elementary ones. Since the icons and stylesheet are already included in the Flatpak platform, we can assume they exist