### PR TITLE
Metainfo: Use branding tag and screenshot caption

### DIFF
--- a/data/music.appdata.xml.in
+++ b/data/music.appdata.xml.in
@@ -14,9 +14,16 @@
 
   <screenshots>
     <screenshot type="default">
+      <caption>Quickly queue up your favorite tracks</caption>
       <image>https://raw.githubusercontent.com/elementary/music/main/data/screenshot.png</image>
     </screenshot>
   </screenshots>
+
+  <branding>
+    <color type="primary">#f37329</color>
+    <color type="primary" scheme_preference="light">#cc3b02</color>
+    <color type="primary" scheme_preference="dark">#ffa154</color>
+  </branding>
 
   <content_rating type="oars-1.1" />
 


### PR DESCRIPTION
Works with https://github.com/elementary/appcenter/pull/1883

Also add `light` and `dark` colors for future use in AppCenter