### PR TITLE
Work around play icon spinner sometimes not spinning.

### DIFF
--- a/src/PlaybackManager.vala
+++ b/src/PlaybackManager.vala
@@ -114,6 +114,7 @@ public class Music.PlaybackManager : Object {
         if (current_audio == null) {
             var audio_object = (AudioObject) queue_liststore.get_object (0);
             if (audio_object != null) {
+                // Timeout is a workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/4426
                 GLib.Timeout.add (250, () => {
                     current_audio = audio_object;
                     return Source.REMOVE;

--- a/src/PlaybackManager.vala
+++ b/src/PlaybackManager.vala
@@ -118,7 +118,10 @@ public class Music.PlaybackManager : Object {
         if (current_audio == null) {
             var audio_object = (AudioObject) queue_liststore.get_object (0);
             if (audio_object != null) {
-                current_audio = audio_object;
+                GLib.Timeout.add (250, () => {
+                    current_audio = audio_object;
+                    return Source.REMOVE;
+                });
             }
         } else {
             // Don't notify on app startup or if the app is focused

--- a/src/Widgets/TrackRow.vala
+++ b/src/Widgets/TrackRow.vala
@@ -23,9 +23,7 @@ public class Music.TrackRow : Gtk.ListBoxRow {
     }
 
     construct {
-        play_icon = new Gtk.Spinner () {
-            spinning = playback_manager.current_audio == audio_object
-        };
+        play_icon = new Gtk.Spinner ();
         play_icon.get_style_context ().add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var album_image = new Music.AlbumImage ();
@@ -65,7 +63,11 @@ public class Music.TrackRow : Gtk.ListBoxRow {
         audio_object.bind_property ("texture", album_image.image, "paintable", BindingFlags.SYNC_CREATE);
 
         playback_manager.notify["current-audio"].connect (() => {
-            play_icon.spinning = playback_manager.current_audio == audio_object;
+            play_icon.spinning = false;
+            GLib.Timeout.add (250, () => {
+                play_icon.spinning = playback_manager.current_audio == audio_object;
+                return Source.REMOVE;
+            });
         });
 
         var play_pause_action = (SimpleAction) GLib.Application.get_default ().lookup_action (Application.ACTION_PLAY_PAUSE);
@@ -80,10 +82,13 @@ public class Music.TrackRow : Gtk.ListBoxRow {
     }
 
     private void update_playing (bool playing) {
-        if (playing) {
-            play_icon.add_css_class ("playing");
-        } else {
-            play_icon.remove_css_class ("playing");
-        }
+        GLib.Timeout.add (250, () => {
+            if (playing) {
+                play_icon.add_css_class ("playing");
+            } else {
+                play_icon.remove_css_class ("playing");
+            }
+            return Source.REMOVE;
+        });
     }
 }

--- a/src/Widgets/TrackRow.vala
+++ b/src/Widgets/TrackRow.vala
@@ -64,6 +64,7 @@ public class Music.TrackRow : Gtk.ListBoxRow {
 
         playback_manager.notify["current-audio"].connect (() => {
             play_icon.spinning = false;
+            // Timeout is a workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/4426
             GLib.Timeout.add (250, () => {
                 play_icon.spinning = playback_manager.current_audio == audio_object;
                 return Source.REMOVE;
@@ -82,6 +83,7 @@ public class Music.TrackRow : Gtk.ListBoxRow {
     }
 
     private void update_playing (bool playing) {
+        // Timeout is a workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/4426
         GLib.Timeout.add (250, () => {
             if (playing) {
                 play_icon.add_css_class ("playing");


### PR DESCRIPTION
Fixes in three places:

* When you first open the app then select multiple tracks from the Files app the first track play icon spinner was stuck.
* When selecting different tracks in the playlist/queue the spinner would sometimes get stuck.
* When clicking the play/pause button repeatedly sometimes the spinner would get stuck.