### PR TITLE
Handle dropped folder

### DIFF
--- a/data/music.metainfo.xml.in
+++ b/data/music.metainfo.xml.in
@@ -51,6 +51,15 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
+    <release version="7.1.0" date="2023-02-09" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+        <ul>
+          <li>Drag and drop whole folders into the queue</li>
+        </ul>
+      </description>
+    </release>
+
     <release version="7.0.1" date="2022-12-05" urgency="medium">
       <description>
         <p>Improvements:</p>
@@ -89,13 +98,6 @@
       </description>
     </release>
 
-    <release version="5.0.5" date="2020-03-04" urgency="medium">
-      <description>
-        <p>Fix removing items from the queue</p>
-        <p>Fix equalizer sliders not properly disabled sometimes</p>
-        <p>Updated translations</p>
-        <p>Performance improvements</p>
-      </description>
-    </release>
+    <release version="5.0.5" date="2020-03-04" urgency="medium"/>
   </releases>
 </component>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -127,7 +127,6 @@ public class Music.MainWindow : Gtk.ApplicationWindow {
                 }
 
                 file_list.reverse ();
-                //TODO Order the files in some way.
                 foreach (unowned var file in file_list) {
                     files += file;
                 }
@@ -177,8 +176,6 @@ public class Music.MainWindow : Gtk.ApplicationWindow {
                 if (info.get_file_type () == FileType.DIRECTORY) {
                     prepend_directory_files (child, ref file_list);
                 } else {
-                    //TODO Check file is a playable type
-                    //TODO Check number of files within limits?
                     file_list.prepend (child);
                 }
             }


### PR DESCRIPTION
Fixes #734 

This PR adds files contained within a dropped folder and within any subfolders to the queue.
