### PR TITLE
MainWindow: Gtk.DropTarget: use drop instead on_drop

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -113,7 +113,7 @@ public class Music.MainWindow : Gtk.ApplicationWindow {
 
         update_repeat_button ();
 
-        drop_target.on_drop.connect ((target, value, x, y) => {
+        drop_target.drop.connect ((target, value, x, y) => {
             if (value.type () == typeof (Gdk.FileList)) {
                 File[] files;
                 SList<File> file_list = null;


### PR DESCRIPTION
- `on_drop` is deprecated but easily replaceable with `drop`
- Fixes a compiler warning

see [valadoc](https://valadoc.org/gtk4/Gtk.DropTarget.on_drop.html)