### PR TITLE
meson: Fix build warning

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,7 +1,7 @@
 gresource = gnome.compile_resources(
     'music-resources',
     'music.gresource.xml',
-    source_dir: join_paths(meson.source_root(), 'data')
+    source_dir: join_paths(meson.project_source_root(), 'data')
 )
 
 install_data(
@@ -13,7 +13,7 @@ install_data(
 i18n.merge_file(
     input: 'music.desktop.in',
     output: meson.project_name() + '.desktop',
-    po_dir: join_paths(meson.source_root(), 'po', 'extra'),
+    po_dir: join_paths(meson.project_source_root(), 'po', 'extra'),
     type: 'desktop',
     install: true,
     install_dir: join_paths(get_option('datadir'), 'applications')
@@ -22,7 +22,7 @@ i18n.merge_file(
 i18n.merge_file(
     input: 'music.metainfo.xml.in',
     output: meson.project_name() + '.metainfo.xml',
-    po_dir: meson.source_root() / 'po' / 'extra',
+    po_dir: meson.project_source_root() / 'po' / 'extra',
     type: 'xml',
     install: true,
     install_dir: get_option('datadir') / 'metainfo',

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,5 +1,5 @@
 i18n.gettext('extra',
-    args: '--directory='+meson.source_root(),
+    args: '--directory='+meson.project_source_root(),
     install: false,
     preset: 'glib'
 )

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,5 +1,5 @@
 i18n.gettext(meson.project_name(),
-    args: '--directory=' + meson.source_root(),
+    args: '--directory=' + meson.project_source_root(),
     preset: 'glib'
 )
 subdir('extra')


### PR DESCRIPTION
Fix the following warning:

```
WARNING: Deprecated features used:
 * 0.56.0: {'meson.source_root'}
```