### PR TITLE
Add clear queue button

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -10,6 +10,7 @@ public class Music.Application : Gtk.Application {
     public const string ACTION_PREVIOUS = "action-previous";
     public const string ACTION_SHUFFLE = "action-shuffle";
     public const string ACTION_FIND = "action-find";
+    public const string ACTION_CLEAR_QUEUE = "action-clear-queue";
     public const string ACTION_QUIT = "action-quit";
 
     private const ActionEntry[] ACTION_ENTRIES = {
@@ -18,6 +19,7 @@ public class Music.Application : Gtk.Application {
         { ACTION_PREVIOUS, action_previous },
         { ACTION_SHUFFLE, action_shuffle },
         { ACTION_FIND, action_find },
+        { ACTION_CLEAR_QUEUE, action_clear_queue },
         { ACTION_QUIT, quit }
     };
 
@@ -188,6 +190,10 @@ public class Music.Application : Gtk.Application {
 
     private void action_find () {
         ((MainWindow)active_window).start_search ();
+    }
+
+    private void action_clear_queue () {
+        playback_manager.clear_queue ();
     }
 
     private void on_bus_acquired (DBusConnection connection, string name) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -73,8 +73,23 @@ public class Music.MainWindow : Gtk.ApplicationWindow {
 
         add_button_label.mnemonic_widget = add_button;
 
+        var clear_button_label = new Gtk.Label (_("Clear Queue"));
+
+        var clear_button_box = new Gtk.Box (HORIZONTAL, 0);
+        clear_button_box.append (new Gtk.Image.from_icon_name ("edit-delete-symbolic"));
+        clear_button_box.append (clear_button_label);
+
+        var clear_button = new Gtk.Button () {
+            child = clear_button_box,
+            action_name = Application.ACTION_PREFIX + Application.ACTION_CLEAR_QUEUE
+        };
+        clear_button.add_css_class (Granite.STYLE_CLASS_FLAT);
+
+        clear_button_label.mnemonic_widget = clear_button;
+
         var queue_action_bar = new Gtk.ActionBar ();
         queue_action_bar.pack_start (add_button);
+        queue_action_bar.pack_end (clear_button);
 
         var queue = new Adw.ToolbarView () {
             bottom_bar_style = RAISED,

--- a/src/PlaybackManager.vala
+++ b/src/PlaybackManager.vala
@@ -145,6 +145,12 @@ public class Music.PlaybackManager : Object {
         }
     }
 
+    public void clear_queue () {
+        playbin.set_state (Gst.State.NULL);
+        current_audio = null;
+        queue_liststore.remove_all ();
+    }
+
     private void update_metadata (Gst.PbUtils.DiscovererInfo info, Error? err) {
         string uri = info.get_uri ();
         switch (info.get_result ()) {


### PR DESCRIPTION
Adds a button to remove all elements from the queue.
One of the features requested in #779 
![music-clear-queue](https://github.com/user-attachments/assets/63cfb940-d966-4b06-b82f-46d0d630ea1f)


