### PR TITLE
Remove songs

### DIFF
--- a/src/PlaybackManager.vala
+++ b/src/PlaybackManager.vala
@@ -151,6 +151,17 @@ public class Music.PlaybackManager : Object {
         queue_liststore.remove_all ();
     }
 
+    public void remove (AudioObject song) {
+        if (song == current_audio) {
+            playbin.set_state (Gst.State.NULL);
+            current_audio = null;
+        }
+
+        uint position;
+        queue_liststore.find (song, out position);
+        queue_liststore.remove (position);
+    }
+
     private void update_metadata (Gst.PbUtils.DiscovererInfo info, Error? err) {
         string uri = info.get_uri ();
         switch (info.get_result ()) {

--- a/src/Widgets/TrackRow.vala
+++ b/src/Widgets/TrackRow.vala
@@ -82,6 +82,7 @@ public class Music.TrackRow : Gtk.ListBoxRow {
         row_action_group.add_action (action_remove);
 
         insert_action_group ("trackrow", row_action_group);
+        add_binding_action (Gdk.Key.Delete, Gdk.ModifierType.NO_MODIFIER_MASK, "trackrow.remove", null);
 
         var menu = new Menu ();
         menu.append (_("Remove"), "trackrow.remove");
@@ -106,7 +107,6 @@ public class Music.TrackRow : Gtk.ListBoxRow {
         });
 
         add_controller (right_click);
-
     }
 
     private void update_playing (bool playing) {

--- a/src/Widgets/TrackRow.vala
+++ b/src/Widgets/TrackRow.vala
@@ -73,6 +73,40 @@ public class Music.TrackRow : Gtk.ListBoxRow {
             }
         });
 
+        var action_remove = new SimpleAction ("remove", null);
+        action_remove.activate.connect (() => {
+            playback_manager.remove (this.audio_object);
+        });
+
+        var row_action_group = new SimpleActionGroup ();
+        row_action_group.add_action (action_remove);
+
+        insert_action_group ("trackrow", row_action_group);
+
+        var menu = new Menu ();
+        menu.append (_("Remove"), "trackrow.remove");
+
+        var context_menu = new Gtk.PopoverMenu.from_model (menu) {
+            halign = Gtk.Align.START,
+            has_arrow = false,
+            position = Gtk.PositionType.BOTTOM
+        };
+        context_menu.set_parent (this);
+
+        var right_click = new Gtk.GestureClick () {
+            button = Gdk.BUTTON_SECONDARY
+        };
+        right_click.pressed.connect ((n_press, x, y) => {
+            var rect = Gdk.Rectangle () {
+                x = (int) x,
+                y = (int) y
+            };
+            context_menu.pointing_to = rect;
+            context_menu.popup ();
+        });
+
+        add_controller (right_click);
+
     }
 
     private void update_playing (bool playing) {

--- a/src/Widgets/TrackRow.vala
+++ b/src/Widgets/TrackRow.vala
@@ -106,7 +106,18 @@ public class Music.TrackRow : Gtk.ListBoxRow {
             context_menu.popup ();
         });
 
+        var long_press = new Gtk.GestureLongPress ();
+        long_press.pressed.connect ((x, y) => {
+            var rect = Gdk.Rectangle () {
+                x = (int) x,
+                y = (int) y
+            };
+            context_menu.pointing_to = rect;
+            context_menu.popup ();
+        });
+
         add_controller (right_click);
+        add_controller (long_press);
     }
 
     private void update_playing (bool playing) {


### PR DESCRIPTION
This adds the ability to remove single items from the queue, either by right clicking on the item or by using the "delete" keyboard shortcut on the selected item.
Fixes #787 
and implements another feature of #779 

![Screenshot from 2025-03-23 10 09 40](https://github.com/user-attachments/assets/e6c15ef0-7d2b-4cad-85a5-0683d1833844)

Currently right clicking the song doesn't select it. This can make it hard to know which song will be affected by the action if you clicked somewhere in between two songs, because there is no visual cue to tell which song is selected. But I think that will be easier to fix that after we merged #796 

