### PR TITLE
Load cover art more efficiently

### DIFF
--- a/src/CoverCache.vala
+++ b/src/CoverCache.vala
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ */
+
+[SingleInstance]
+public class Music.CoverCache : Object {
+    private HashTable<string, Gdk.Texture> loaded_covers;
+
+    construct {
+        loaded_covers = new HashTable<string, Gdk.Texture> (str_hash, str_equal);
+    }
+
+    public Gdk.Texture? get_cover (string album) {
+        return loaded_covers.get (album);
+    }
+
+    public Gdk.Texture? add_cover (string album, Gdk.Pixbuf pix) {
+        Gdk.Texture cover = Gdk.Texture.for_pixbuf (pix);
+        loaded_covers.insert (album, cover);
+        return cover;
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,7 @@ sources = [
     'AudioObject.vala',
     'MainWindow.vala',
     'PlaybackManager.vala',
+    'CoverCache.vala',
     'DBus/MprisPlayer.vala',
     'DBus/MprisRoot.vala',
     'Views/NowPlayingView.vala',


### PR DESCRIPTION
Currently Music loads the cover art for every single song added to the queue into memory, no matter if the same cover art was already used by other songs. When opening multiple albums at once this can quickly lead to a lot of memory being wasted.
So I implemented a simple cover cache that makes sure that each individual cover only gets loaded into memory once and is then reused by songs from the same album.

This is still WIP. Just putting it here to avoid that someone else unnecessarily starts working on the same thing.