### PR TITLE
Attempt at save/restoring queue

### DIFF
--- a/data/music.gschema.xml
+++ b/data/music.gschema.xml
@@ -12,6 +12,11 @@
       <summary>An index representing the repeat mode</summary>
       <description>An index representing the repeat mode</description>
     </key>
+    <key type="as" name="previous-queue">
+      <default>['']</default>
+      <summary>The queue from last session to restore</summary>
+      <description>An array of strings representing the files played last</description>
+    </key>
 
     <key name="window-height" type="i">
       <default>475</default>

--- a/data/music.gschema.xml
+++ b/data/music.gschema.xml
@@ -13,7 +13,7 @@
       <description>An index representing the repeat mode</description>
     </key>
     <key type="as" name="previous-queue">
-      <default>[]</default>
+      <default>['']</default>
       <summary>The queue from last session to restore</summary>
       <description>An array of strings representing the files played last</description>
     </key>

--- a/data/music.gschema.xml
+++ b/data/music.gschema.xml
@@ -17,6 +17,11 @@
       <summary>The queue from last session to restore</summary>
       <description>An array of strings representing the files played last</description>
     </key>
+    <key type="i" name="index-last-played">
+      <default>0</default>
+      <summary>The item that was playing when the user closed Music</summary>
+      <description>An Integer representing the position in the ListStore of the last played music file</description>
+    </key>
 
     <key name="window-height" type="i">
       <default>475</default>

--- a/data/music.gschema.xml
+++ b/data/music.gschema.xml
@@ -17,10 +17,10 @@
       <summary>The queue from last session to restore</summary>
       <description>An array of strings representing the files played last</description>
     </key>
-    <key type="i" name="index-last-played">
-      <default>0</default>
+    <key type="s" name="uri-last-played">
+      <default>''</default>
       <summary>The item that was playing when the user closed Music</summary>
-      <description>An Integer representing the position in the ListStore of the last played music file</description>
+      <description>A string representing the uri of the last played music file</description>
     </key>
 
     <key name="window-height" type="i">

--- a/data/music.gschema.xml
+++ b/data/music.gschema.xml
@@ -13,7 +13,7 @@
       <description>An index representing the repeat mode</description>
     </key>
     <key type="as" name="previous-queue">
-      <default>['']</default>
+      <default>[]</default>
       <summary>The queue from last session to restore</summary>
       <description>An array of strings representing the files played last</description>
     </key>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -100,6 +100,10 @@ public class Music.Application : Gtk.Application {
 
         add_window (main_window);
 
+        // This needs to be done after window is constructed
+        // Else music plays but the queue seems empty
+        PlaybackManager.get_default ().restore_queue ();
+
         /*
         * This is very finicky. Bind size after present else set_titlebar gives us bad sizes
         * Set maximize after height/width else window is min size on unmaximize
@@ -114,6 +118,7 @@ public class Music.Application : Gtk.Application {
         }
 
         settings.bind ("window-maximized", main_window, "maximized", SettingsBindFlags.SET);
+
     }
 
     private static File[] list_directory (string directory) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -100,10 +100,6 @@ public class Music.Application : Gtk.Application {
 
         add_window (main_window);
 
-        // This needs to be done after window is constructed
-        // Else music plays but the queue seems empty
-        PlaybackManager.get_default ().restore_queue ();
-
         /*
         * This is very finicky. Bind size after present else set_titlebar gives us bad sizes
         * Set maximize after height/width else window is min size on unmaximize
@@ -118,6 +114,16 @@ public class Music.Application : Gtk.Application {
         }
 
         settings.bind ("window-maximized", main_window, "maximized", SettingsBindFlags.SET);
+
+        // Restoring the queue overwrites the last played. So we need to retrieve it before
+        var? uri_last_played = settings.get_string ("uri-last-played");
+
+        // This needs to be done after window is constructed
+        // Else music plays but the queue seems empty
+        PlaybackManager.get_default ().restore_queue ();
+
+        settings.set_string ("uri-last-played", uri_last_played);
+        PlaybackManager.get_default ().restore_last_played ();
 
     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -247,17 +247,6 @@ public class Music.MainWindow : Gtk.ApplicationWindow {
         close_request.connect (e => {
             return before_destroy ();
         });
-
-        var last_session_uri = settings.get_strv ("previous-queue");
-        var last_session_files = new File[last_session_uri.length];
-
-        foreach (var uri in last_session_uri) {
-            var file = File.new_for_uri (uri);
-            last_session_files += file;
-        }
-
-        var files_to_play = Application.loop_through_files (last_session_files);
-        PlaybackManager.get_default ().queue_files (files_to_play);
     }
 
     public void start_search () {
@@ -351,8 +340,10 @@ public class Music.MainWindow : Gtk.ApplicationWindow {
 
         for (var i = 0; i < current_queue.n_items; i++) {
             var item = (Music.AudioObject)current_queue.get_item (i);
+            print("\n" + item.uri);
             list_uri += item.uri;
         }
+        print(list_uri.length.to_string());
 
         settings.set_strv ("previous-queue", list_uri);
         return false;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -243,10 +243,6 @@ public class Music.MainWindow : Gtk.ApplicationWindow {
                 playback_manager.current_audio = selected_audio;
             }
         });
-
-        close_request.connect (e => {
-            return before_destroy ();
-        });
     }
 
     public void start_search () {
@@ -332,20 +328,5 @@ public class Music.MainWindow : Gtk.ApplicationWindow {
         } else {
             queue_stack.visible_child = queue_placeholder;
         }
-    }
-
-    private bool before_destroy () {
-        var current_queue = PlaybackManager.get_default ().queue_liststore;
-        string[] list_uri = new string[current_queue.n_items];
-
-        for (var i = 0; i < current_queue.n_items; i++) {
-            var item = (Music.AudioObject)current_queue.get_item (i);
-            print("\n" + item.uri);
-            list_uri += item.uri;
-        }
-        print(list_uri.length.to_string());
-
-        settings.set_strv ("previous-queue", list_uri);
-        return false;
     }
 }

--- a/src/PlaybackManager.vala
+++ b/src/PlaybackManager.vala
@@ -459,6 +459,7 @@ public class Music.PlaybackManager : Object {
 
         var files_to_play = Application.loop_through_files (last_session_files);
         queue_files (files_to_play);
+        //playback_position = (int)settings.get_int ("index-last-played");
     }
 
     private void on_items_changed () {
@@ -476,5 +477,6 @@ public class Music.PlaybackManager : Object {
         }
 
         settings.set_strv ("previous-queue", list_uri);
+        //settings.set_int ("index-last-played", (int)playback_position);
     }
 }

--- a/src/PlaybackManager.vala
+++ b/src/PlaybackManager.vala
@@ -83,6 +83,8 @@ public class Music.PlaybackManager : Object {
         });
 
         settings = new Settings ("io.elementary.music");
+
+        restore_queue ();
     }
 
     public void seek_to_progress (double percent) {
@@ -450,5 +452,19 @@ public class Music.PlaybackManager : Object {
         buffer.unmap (map_info);
 
         return pix;
+    }
+
+    private void restore_queue () {
+        var last_session_uri = settings.get_strv ("previous-queue");
+        var last_session_files = new File[last_session_uri.length];
+
+        foreach (var uri in last_session_uri) {
+            print("\n" + uri);
+            var file = File.new_for_uri (uri);
+            last_session_files += file;
+        }
+
+        var files_to_play = Application.loop_through_files (last_session_files);
+        queue_files (files_to_play);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/elementary/music/issues/792

This is not ready yet.
The new key in gschema does not seem to install at all. I am trying to figure this out.

-After constructing the window and adding all the signals, when everything is ready, start loading previous queue 
-Handle a close request for the window, the handler slorps everything in the queue in gsettings

alternatively i could change the plumbing to have the app save in realtime whenever the liststore gets changed. This would keep state despite a crash, but it feels gross constantly writing to gsettings
