### PR TITLE
gschema: Fix invalid default value for previous-queue

### DIFF
--- a/data/music.gschema.xml
+++ b/data/music.gschema.xml
@@ -13,7 +13,7 @@
       <description>An index representing the repeat mode</description>
     </key>
     <key type="as" name="previous-queue">
-      <default>['']</default>
+      <default>[]</default>
       <summary>The queue from last session to restore</summary>
       <description>An array of strings representing the files played last</description>
     </key>

--- a/src/PlaybackManager.vala
+++ b/src/PlaybackManager.vala
@@ -530,6 +530,10 @@ public class Music.PlaybackManager : Object {
         var file_last_played = File.new_for_uri (uri_last_played);
 
         var last_session_uri = settings.get_strv ("previous-queue");
+        if (last_session_uri.length == 0) {
+            return;
+        }
+
         var last_session_files = new File[last_session_uri.length];
 
         for (var i = 0; i < last_session_uri.length; i++) {


### PR DESCRIPTION
Fixes #829

The default value of `previous-queue` is a string array with one element that has a blank URI. This results `last_session_uri.length` is not `0` but `1`, causing `last_session_files` has one File that has a blank URI.

https://github.com/elementary/music/blob/c2fc713067c0751bd5dc544f04fd5e7125dbf779/src/PlaybackManager.vala#L527-L541

causing the terminal warning here

https://github.com/elementary/music/blob/c2fc713067c0751bd5dc544f04fd5e7125dbf779/src/Application.vala#L141

and causing the toast popup here

https://github.com/elementary/music/blob/c2fc713067c0751bd5dc544f04fd5e7125dbf779/src/PlaybackManager.vala#L104-L130
