### PR TITLE
Adds an "Open Folder…" button to open folders only

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -131,6 +131,9 @@ public class Music.Application : Gtk.Application {
         return elements;
     }
 
+    /**
+     * Flattens files and those contained in (sub)directories
+     */
     public static File[] loop_through_files (File[] files) {
         // All of these will be returned later in bulk
         File[] elements = {};

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -6,6 +6,7 @@
 public class Music.MainWindow : Gtk.ApplicationWindow {
     public const string ACTION_PREFIX = "win.";
     public const string ACTION_OPEN = "action-open";
+    public const string ACTION_OPEN_FOLDER = "action-open-folder";
 
     private QueueView queue_view;
 
@@ -61,8 +62,13 @@ public class Music.MainWindow : Gtk.ApplicationWindow {
         open_action.activate.connect (open_files);
         add_action (open_action);
 
+        var open_folder_action = new SimpleAction (ACTION_OPEN_FOLDER, null);
+        open_folder_action.activate.connect (open_folder);
+        add_action (open_folder_action);
+
         unowned var app = ((Gtk.Application) GLib.Application.get_default ());
         app.set_accels_for_action (ACTION_PREFIX + ACTION_OPEN, {"<Ctrl>O"});
+        app.set_accels_for_action (ACTION_PREFIX + ACTION_OPEN_FOLDER, {"<Ctrl><Shift>O"});
     }
 
     public void start_search () {
@@ -96,30 +102,59 @@ public class Music.MainWindow : Gtk.ApplicationWindow {
             try {
                 var files = file_dialog.open_multiple.end (res);
 
-                File[] file_array = {};
-                for (int i = 0; i < files.get_n_items (); i++) {
-                    file_array += (File)(files.get_item (i));
-                }
-
-                var files_to_play = Application.loop_through_files (file_array);
-                PlaybackManager.get_default ().queue_files (files_to_play);
+                handle_selected_files (files);
             } catch (Error e) {
-                if (e.matches (Gtk.DialogError.quark (), Gtk.DialogError.DISMISSED)) {
-                    return;
-                }
-
-                var dialog = new Granite.MessageDialog (
-                    _("Couldn't add audio files"),
-                    e.message,
-                    new ThemedIcon ("document-open")
-                ) {
-                    badge_icon = new ThemedIcon ("dialog-error"),
-                    modal = true,
-                    transient_for = this
-                };
-                dialog.present ();
-                dialog.response.connect (dialog.destroy);
+                handle_file_dialog_error (e);
             }
         });
+    }
+
+    /**
+     * Same as open_files, except there is not filter and it uses the Folder dialog :
+     *  No folder/file is pre-selected when entering a directory and individual files cannot be selected
+     */
+    private void open_folder () {
+        var file_dialog = new Gtk.FileDialog () {
+            accept_label = _("Open"),
+            modal = true,
+            title = _("Open folder(s) containing audio files")
+        };
+
+        file_dialog.select_multiple_folders.begin (this, null, (obj, res) => {
+            try {
+                var folders = file_dialog.select_multiple_folders.end (res);
+
+                handle_selected_files (folders);
+            } catch (Error e) {
+                handle_file_dialog_error (e);
+            }
+        });
+    }
+
+    private void handle_selected_files (GLib.ListModel files) {
+        File[] file_array = {};
+        for (int i = 0; i < files.get_n_items (); i++) {
+            file_array += (File)(files.get_item (i));
+        }
+        var files_to_play = Application.loop_through_files (file_array);
+        PlaybackManager.get_default ().queue_files (files_to_play);
+    }
+
+    private void handle_file_dialog_error (Error e) {
+        if (e.matches (Gtk.DialogError.quark (), Gtk.DialogError.DISMISSED)) {
+            return;
+        }
+
+        var dialog = new Granite.MessageDialog (
+            _("Couldn't add audio files"),
+            e.message,
+            new ThemedIcon ("document-open")
+        ) {
+            badge_icon = new ThemedIcon ("dialog-error"),
+            modal = true,
+            transient_for = this
+        };
+        dialog.present ();
+        dialog.response.connect (dialog.destroy);
     }
 }

--- a/src/Views/QueueView.vala
+++ b/src/Views/QueueView.vala
@@ -78,7 +78,6 @@ public class Music.QueueView : Granite.Bin {
         var drop_target = new Gtk.DropTarget (typeof (Gdk.FileList), Gdk.DragAction.COPY);
 
         var add_button_label = new Gtk.Label (_("Open Files…"));
-
         var add_button_box = new Gtk.Box (HORIZONTAL, 0);
         add_button_box.append (new Gtk.Image.from_icon_name ("document-open-symbolic"));
         add_button_box.append (add_button_label);
@@ -88,8 +87,19 @@ public class Music.QueueView : Granite.Bin {
             action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_OPEN
         };
         add_button.add_css_class (Granite.STYLE_CLASS_FLAT);
-
         add_button_label.mnemonic_widget = add_button;
+
+        var add_folder_button_label = new Gtk.Label (_("Open Folder…"));
+        var add_folder_button_box = new Gtk.Box (HORIZONTAL, 0);
+        add_folder_button_box.append (new Gtk.Image.from_icon_name ("document-open-symbolic"));
+        add_folder_button_box.append (add_folder_button_label);
+
+        var add_folder_button = new Gtk.Button () {
+            child = add_folder_button_box,
+            action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_OPEN_FOLDER
+        };
+        add_folder_button.add_css_class (Granite.STYLE_CLASS_FLAT);
+        add_folder_button_label.mnemonic_widget = add_folder_button;
 
         var clear_button_label = new Gtk.Label (_("Clear Queue"));
 
@@ -107,6 +117,7 @@ public class Music.QueueView : Granite.Bin {
 
         var queue_action_bar = new Gtk.ActionBar ();
         queue_action_bar.pack_start (add_button);
+        queue_action_bar.pack_start (add_folder_button);
         queue_action_bar.pack_end (clear_button);
 
         var queue = new Adw.ToolbarView () {


### PR DESCRIPTION
- Eases the import of directories by never selecting an element. This way, the "Open" button opens the current directory instead of import the selected file(s)/folder(s).
  - Validating with "Open" imports the current directory and its subdirectories (if no element has been manually selected)
- Prevents selecting individual files
- Assign CTRL + SHIFT + O shortcut to the Open Folder dialog

Addresses #832