### PR TITLE
Control: fix maintainer field

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: io.elementary.music
 Section: sound
 Priority: optional
-Maintainer: elementary, Inc. <builds@elementary.io>
+Maintainer: elementary <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
                libadwaita-1-dev (>= 1.4.0),
                libgranite-7-dev (>= 7.6.0),


### PR DESCRIPTION
Builds on Resolute is failing due to this: https://code.launchpad.net/~elementary-os/+recipe/music-daily

```
dpkg-buildpackage: info: source package io.elementary.music
dpkg-buildpackage: info: source version 7.0.0-0+pkg132~daily~ubuntu26.04.1
dpkg-buildpackage: info: source distribution resolute
dpkg-buildpackage: info: source changed by Ryo Nakano <ryonakaknock3@gmail.com>
 dpkg-source -i -I.bzr -I.git --before-build .
dpkg-source: error: cannot parse Maintainer field value "elementary, Inc. <builds@elementary.io>"
dpkg-source: info: using options from /home/buildd/work/tree/recipe/debian/source/options: --tar-ignore=.pc
dpkg-buildpackage: error: dpkg-source -i -I.bzr -I.git --before-build . subprocess failed with exit status 255
[Tue Apr 14 13:09:43 2026]
RUN: /usr/share/launchpad-buildd/bin/in-target scan-for-processes --backend=chroot --series=resolute --abi-tag=amd64 --isa-tag=amd64 RECIPEBRANCHBUILD-4030182
Scanning for processes to kill in build RECIPEBRANCHBUILD-4030182
```